### PR TITLE
feat: Implement Phase 2 capture features — upload, gallery, AI portra…

### DIFF
--- a/app/api/v1/w/[slug]/ai-portrait/[jobId]/route.ts
+++ b/app/api/v1/w/[slug]/ai-portrait/[jobId]/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest } from 'next/server';
+import { getPool } from '@/lib/db/client';
+import { validateSession } from '@/lib/session';
+import { getCdnUrl } from '@/lib/storage/r2';
+import { AppError, handleApiError } from '@/lib/errors';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string; jobId: string }> }
+) {
+  try {
+    const { jobId } = await params;
+    const pool = getPool();
+
+    // Validate guest session
+    const sessionToken = request.cookies.get('wedding_session')?.value;
+    if (!sessionToken) {
+      throw new AppError('AUTH_NOT_REGISTERED');
+    }
+
+    const session = await validateSession(pool, sessionToken);
+    if (!session) {
+      throw new AppError('AUTH_TOKEN_EXPIRED');
+    }
+
+    // Fetch job
+    const result = await pool.query(
+      `SELECT id, status, style_id, output_key, error_message, created_at, completed_at
+       FROM ai_jobs
+       WHERE id = $1 AND wedding_id = $2 AND guest_id = $3`,
+      [jobId, session.weddingId, session.guestId]
+    );
+
+    if (result.rows.length === 0) {
+      throw new AppError('VALIDATION_ERROR', 'Portrait job not found');
+    }
+
+    const job = result.rows[0];
+
+    return Response.json({
+      data: {
+        job_id: job.id,
+        status: job.status,
+        style_id: job.style_id,
+        output_url: job.output_key ? getCdnUrl(job.output_key) : null,
+        error: job.error_message || null,
+        created_at: job.created_at,
+        completed_at: job.completed_at,
+      },
+    });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/app/api/v1/w/[slug]/ai-portrait/route.ts
+++ b/app/api/v1/w/[slug]/ai-portrait/route.ts
@@ -1,0 +1,199 @@
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { v4 as uuidv4 } from 'uuid';
+import { getPool } from '@/lib/db/client';
+import { validateSession } from '@/lib/session';
+import { getCdnUrl } from '@/lib/storage/r2';
+import { checkPortraitQuota } from '@/lib/ai/quota';
+import { getOpenAIClient, AI_PORTRAIT_STYLES, IMAGE_MODEL, type PortraitStyleId } from '@/lib/ai/openai';
+import { AppError, handleApiError } from '@/lib/errors';
+import { isTestMode } from '@/lib/env';
+
+const generateSchema = z.object({
+  source_upload_id: z.string().uuid(),
+  style_id: z.string().refine(
+    (v) => v in AI_PORTRAIT_STYLES,
+    'Invalid portrait style'
+  ),
+});
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  try {
+    const { slug } = await params;
+    const pool = getPool();
+
+    // Validate guest session
+    const sessionToken = request.cookies.get('wedding_session')?.value;
+    if (!sessionToken) {
+      throw new AppError('AUTH_NOT_REGISTERED');
+    }
+
+    const session = await validateSession(pool, sessionToken);
+    if (!session) {
+      throw new AppError('AUTH_TOKEN_EXPIRED');
+    }
+
+    // Validate request body
+    const body = await request.json();
+    const parsed = generateSchema.safeParse(body);
+    if (!parsed.success) {
+      throw new AppError('VALIDATION_ERROR', parsed.error.issues[0]?.message);
+    }
+
+    const { source_upload_id, style_id } = parsed.data;
+
+    // Check AI portraits feature is enabled
+    const weddingResult = await pool.query(
+      `SELECT id, package_config, status FROM weddings WHERE slug = $1`,
+      [slug]
+    );
+    if (weddingResult.rows.length === 0) {
+      throw new AppError('WEDDING_NOT_FOUND');
+    }
+    const wedding = weddingResult.rows[0];
+    if (wedding.id !== session.weddingId) {
+      throw new AppError('AUTH_NOT_REGISTERED');
+    }
+
+    const perGuestLimit = wedding.package_config?.ai_portraits_per_guest || 5;
+
+    // Check quota using a pool client for transaction
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      const quota = await checkPortraitQuota(client, {
+        weddingId: session.weddingId,
+        guestId: session.guestId,
+        perGuestLimit,
+      });
+
+      if (!quota.allowed) {
+        throw new AppError('AI_QUOTA_GUEST', quota.message);
+      }
+
+      // Verify source upload exists and belongs to this guest
+      const uploadResult = await client.query(
+        `SELECT id, storage_key, type FROM uploads
+         WHERE id = $1 AND wedding_id = $2 AND guest_id = $3 AND status = 'ready'`,
+        [source_upload_id, session.weddingId, session.guestId]
+      );
+      if (uploadResult.rows.length === 0) {
+        throw new AppError('VALIDATION_ERROR', 'Source photo not found');
+      }
+      if (uploadResult.rows[0].type !== 'photo') {
+        throw new AppError('VALIDATION_ERROR', 'Source must be a photo');
+      }
+
+      const sourceKey = uploadResult.rows[0].storage_key;
+
+      // Create AI job
+      const jobId = uuidv4();
+      await client.query(
+        `INSERT INTO ai_jobs (id, wedding_id, guest_id, type, style_id, input_key, status, metadata)
+         VALUES ($1, $2, $3, 'portrait', $4, $5, 'queued', $6)`,
+        [jobId, session.weddingId, session.guestId, style_id, sourceKey, JSON.stringify({ source_upload_id })]
+      );
+
+      await client.query('COMMIT');
+
+      // Start generation asynchronously (non-blocking)
+      processPortraitJob(jobId, session.weddingId, session.guestId, sourceKey, style_id as PortraitStyleId).catch(
+        (err) => console.error('Portrait generation failed:', err)
+      );
+
+      return Response.json({
+        data: {
+          job_id: jobId,
+          status: 'queued',
+          style: AI_PORTRAIT_STYLES[style_id as PortraitStyleId],
+          quota: {
+            remaining: quota.remaining - 1,
+            used: quota.used + 1,
+          },
+        },
+      });
+    } catch (e) {
+      await client.query('ROLLBACK');
+      throw e;
+    } finally {
+      client.release();
+    }
+  } catch (error) {
+    return handleApiError(error);
+  }
+}
+
+async function processPortraitJob(
+  jobId: string,
+  weddingId: string,
+  guestId: string,
+  inputKey: string,
+  styleId: PortraitStyleId
+) {
+  const pool = getPool();
+
+  try {
+    // Mark as processing
+    await pool.query(
+      `UPDATE ai_jobs SET status = 'processing', started_at = NOW() WHERE id = $1`,
+      [jobId]
+    );
+
+    const style = AI_PORTRAIT_STYLES[styleId];
+    let outputUrl: string;
+
+    if (isTestMode()) {
+      // Mock response in test mode
+      outputUrl = `https://mock-cdn.example.com/ai/${jobId}/output.png`;
+    } else {
+      const openai = getOpenAIClient();
+      const sourceUrl = getCdnUrl(inputKey);
+
+      // Fetch source image as buffer for OpenAI API
+      const imageResponse = await fetch(sourceUrl);
+      if (!imageResponse.ok) {
+        throw new Error(`Failed to fetch source image: ${imageResponse.status}`);
+      }
+      const imageBlob = await imageResponse.blob();
+      const imageFile = new File([imageBlob], 'source.png', { type: 'image/png' });
+
+      const response = await openai.images.edit({
+        model: IMAGE_MODEL,
+        image: imageFile,
+        prompt: style.prompt,
+        size: '1024x1024' as const,
+      });
+
+      outputUrl = response.data?.[0]?.url || '';
+      if (!outputUrl) {
+        throw new Error('No image URL returned from OpenAI');
+      }
+    }
+
+    // Store result
+    const outputKey = `weddings/${weddingId}/ai/${jobId}/output.png`;
+
+    await pool.query(
+      `UPDATE ai_jobs
+       SET status = 'completed', output_key = $1, completed_at = NOW(), cost_cents = 4
+       WHERE id = $2`,
+      [outputKey, jobId]
+    );
+
+    // Update wedding portrait counter
+    await pool.query(
+      `UPDATE weddings SET ai_portraits_used = ai_portraits_used + 1 WHERE id = $1`,
+      [weddingId]
+    );
+  } catch (error) {
+    const errMessage = error instanceof Error ? error.message : 'Unknown error';
+    await pool.query(
+      `UPDATE ai_jobs SET status = 'failed', error_message = $1, completed_at = NOW() WHERE id = $2`,
+      [errMessage, jobId]
+    );
+  }
+}

--- a/app/api/v1/w/[slug]/faq/route.ts
+++ b/app/api/v1/w/[slug]/faq/route.ts
@@ -1,0 +1,174 @@
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { getPool } from '@/lib/db/client';
+import { validateSession } from '@/lib/session';
+import { getOpenAIClient, CHAT_MODEL_MINI, EMBEDDING_MODEL } from '@/lib/ai/openai';
+import { sanitizeText } from '@/lib/validation';
+import { AppError, handleApiError } from '@/lib/errors';
+import { isTestMode } from '@/lib/env';
+import { createHash } from 'crypto';
+
+const askSchema = z.object({
+  question: z.string().min(2).max(500),
+});
+
+// POST /api/v1/w/[slug]/faq — ask a question
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  try {
+    const { slug } = await params;
+    const pool = getPool();
+
+    // Validate guest session
+    const sessionToken = request.cookies.get('wedding_session')?.value;
+    if (!sessionToken) {
+      throw new AppError('AUTH_NOT_REGISTERED');
+    }
+
+    const session = await validateSession(pool, sessionToken);
+    if (!session) {
+      throw new AppError('AUTH_TOKEN_EXPIRED');
+    }
+
+    // Check FAQ feature is enabled
+    const weddingResult = await pool.query(
+      `SELECT id, package_config, display_name, config FROM weddings WHERE slug = $1`,
+      [slug]
+    );
+    if (weddingResult.rows.length === 0) {
+      throw new AppError('WEDDING_NOT_FOUND');
+    }
+    if (weddingResult.rows[0].id !== session.weddingId) {
+      throw new AppError('AUTH_NOT_REGISTERED');
+    }
+
+    const pkgConfig = weddingResult.rows[0].package_config || {};
+    if (pkgConfig.faq_chatbot === false) {
+      throw new AppError('BILLING_FEATURE_LOCKED');
+    }
+
+    // Validate body
+    const body = await request.json();
+    const parsed = askSchema.safeParse(body);
+    if (!parsed.success) {
+      throw new AppError('VALIDATION_ERROR', parsed.error.issues[0]?.message);
+    }
+
+    const question = sanitizeText(parsed.data.question);
+
+    // Check cache first
+    const questionHash = createHash('sha256').update(question.toLowerCase().trim()).digest('hex');
+    const cacheResult = await pool.query(
+      `SELECT answer FROM faq_cache WHERE wedding_id = $1 AND question_hash = $2`,
+      [session.weddingId, questionHash]
+    );
+
+    if (cacheResult.rows.length > 0) {
+      // Increment hit count
+      await pool.query(
+        `UPDATE faq_cache SET hit_count = hit_count + 1 WHERE wedding_id = $1 AND question_hash = $2`,
+        [session.weddingId, questionHash]
+      );
+
+      return Response.json({
+        data: {
+          answer: cacheResult.rows[0].answer,
+          cached: true,
+          sources: [],
+        },
+      });
+    }
+
+    // Get FAQ entries for this wedding
+    const faqResult = await pool.query(
+      `SELECT id, question, answer FROM faq_entries WHERE wedding_id = $1`,
+      [session.weddingId]
+    );
+
+    const weddingName = weddingResult.rows[0].display_name;
+    let answer: string;
+    let sources: { question: string; answer: string }[] = [];
+
+    if (isTestMode()) {
+      answer = `Here's what I know about "${question}" for ${weddingName}: This is a mock FAQ response. Please check with the couple for specific details.`;
+      sources = faqResult.rows.slice(0, 2).map((r) => ({ question: r.question, answer: r.answer }));
+    } else if (faqResult.rows.length === 0) {
+      answer = `I don't have specific information about that yet. The couple hasn't added FAQ entries. You might want to reach out to them directly!`;
+    } else {
+      // Use embeddings to find the most relevant FAQ entries
+      const openai = getOpenAIClient();
+
+      // Generate embedding for the question
+      const embeddingResponse = await openai.embeddings.create({
+        model: EMBEDDING_MODEL,
+        input: question,
+      });
+      const questionEmbedding = embeddingResponse.data[0].embedding;
+
+      // Search for similar FAQ entries using pgvector
+      const embeddingStr = `[${questionEmbedding.join(',')}]`;
+      const similarResult = await pool.query(
+        `SELECT question, answer, 1 - (embedding <=> $1::vector) as similarity
+         FROM faq_entries
+         WHERE wedding_id = $2 AND embedding IS NOT NULL
+         ORDER BY embedding <=> $1::vector
+         LIMIT 3`,
+        [embeddingStr, session.weddingId]
+      );
+
+      sources = similarResult.rows.map((r) => ({
+        question: r.question,
+        answer: r.answer,
+      }));
+
+      // If we have similar entries, use them as context
+      if (similarResult.rows.length > 0 && similarResult.rows[0].similarity > 0.7) {
+        // High similarity — return FAQ answer directly
+        answer = similarResult.rows[0].answer;
+      } else {
+        // Use GPT to generate a conversational answer from context
+        const context = faqResult.rows
+          .map((r) => `Q: ${r.question}\nA: ${r.answer}`)
+          .join('\n\n');
+
+        const chatResponse = await openai.chat.completions.create({
+          model: CHAT_MODEL_MINI,
+          messages: [
+            {
+              role: 'system',
+              content: `You are a friendly, helpful FAQ assistant for ${weddingName}. Answer guest questions based on the provided FAQ context. Be warm, concise, and conversational. If you're not sure, say so honestly and suggest they ask the couple directly. Never make up specific details like times, addresses, or dress codes that aren't in the context.`,
+            },
+            {
+              role: 'user',
+              content: `FAQ Context:\n${context}\n\nGuest Question: ${question}`,
+            },
+          ],
+          max_tokens: 300,
+          temperature: 0.7,
+        });
+
+        answer = chatResponse.choices[0]?.message?.content || "I'm not sure about that. You might want to ask the couple directly!";
+      }
+    }
+
+    // Cache the answer
+    await pool.query(
+      `INSERT INTO faq_cache (wedding_id, question_hash, answer)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (wedding_id, question_hash) DO UPDATE SET hit_count = faq_cache.hit_count + 1`,
+      [session.weddingId, questionHash, answer]
+    );
+
+    return Response.json({
+      data: {
+        answer,
+        cached: false,
+        sources,
+      },
+    });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/app/api/v1/w/[slug]/feed/[postId]/comments/route.ts
+++ b/app/api/v1/w/[slug]/feed/[postId]/comments/route.ts
@@ -1,0 +1,182 @@
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { getPool } from '@/lib/db/client';
+import { validateSession } from '@/lib/session';
+import { sanitizeText } from '@/lib/validation';
+import { AppError, handleApiError } from '@/lib/errors';
+
+const commentSchema = z.object({
+  content: z.string().min(1).max(500),
+});
+
+// GET /api/v1/w/[slug]/feed/[postId]/comments — list comments
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string; postId: string }> }
+) {
+  try {
+    const { postId } = await params;
+    const pool = getPool();
+
+    // Validate guest session
+    const sessionToken = request.cookies.get('wedding_session')?.value;
+    if (!sessionToken) {
+      throw new AppError('AUTH_NOT_REGISTERED');
+    }
+
+    const session = await validateSession(pool, sessionToken);
+    if (!session) {
+      throw new AppError('AUTH_TOKEN_EXPIRED');
+    }
+
+    // Verify post belongs to this wedding
+    const postResult = await pool.query(
+      `SELECT id, wedding_id FROM feed_posts WHERE id = $1`,
+      [postId]
+    );
+    if (postResult.rows.length === 0) {
+      throw new AppError('FEED_POST_HIDDEN');
+    }
+    if (postResult.rows[0].wedding_id !== session.weddingId) {
+      throw new AppError('AUTH_NOT_REGISTERED');
+    }
+
+    const url = new URL(request.url);
+    const cursor = url.searchParams.get('cursor');
+    const limit = Math.min(parseInt(url.searchParams.get('limit') || '20', 10), 100);
+
+    const conditions = ['c.post_id = $1'];
+    const queryParams: (string | number)[] = [postId];
+    let paramIndex = 2;
+
+    if (cursor) {
+      conditions.push(`c.created_at > $${paramIndex}`);
+      queryParams.push(cursor);
+      paramIndex++;
+    }
+
+    queryParams.push(limit + 1);
+
+    const result = await pool.query(
+      `SELECT c.id, c.content, c.created_at,
+              g.id as guest_id, g.first_name, g.last_name, g.display_name
+       FROM feed_comments c
+       JOIN guests g ON c.guest_id = g.id
+       WHERE ${conditions.join(' AND ')}
+       ORDER BY c.created_at ASC
+       LIMIT $${paramIndex}`,
+      queryParams
+    );
+
+    const hasMore = result.rows.length > limit;
+    const rows = result.rows.slice(0, limit);
+
+    const comments = rows.map((row) => ({
+      id: row.id,
+      content: row.content,
+      guest: {
+        id: row.guest_id,
+        first_name: row.first_name,
+        last_name: row.last_name,
+        display_name: row.display_name,
+      },
+      created_at: row.created_at,
+    }));
+
+    return Response.json({
+      data: {
+        items: comments,
+        next_cursor: hasMore && rows.length > 0 ? rows[rows.length - 1].created_at : null,
+        has_more: hasMore,
+      },
+    });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}
+
+// POST /api/v1/w/[slug]/feed/[postId]/comments — add a comment
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string; postId: string }> }
+) {
+  try {
+    const { postId } = await params;
+    const pool = getPool();
+
+    // Validate guest session
+    const sessionToken = request.cookies.get('wedding_session')?.value;
+    if (!sessionToken) {
+      throw new AppError('AUTH_NOT_REGISTERED');
+    }
+
+    const session = await validateSession(pool, sessionToken);
+    if (!session) {
+      throw new AppError('AUTH_TOKEN_EXPIRED');
+    }
+
+    // Verify post belongs to this wedding and is not hidden
+    const postResult = await pool.query(
+      `SELECT id, wedding_id, is_hidden FROM feed_posts WHERE id = $1`,
+      [postId]
+    );
+    if (postResult.rows.length === 0 || postResult.rows[0].is_hidden) {
+      throw new AppError('FEED_POST_HIDDEN');
+    }
+    if (postResult.rows[0].wedding_id !== session.weddingId) {
+      throw new AppError('AUTH_NOT_REGISTERED');
+    }
+
+    // Validate body
+    const body = await request.json();
+    const parsed = commentSchema.safeParse(body);
+    if (!parsed.success) {
+      throw new AppError('VALIDATION_ERROR', parsed.error.issues[0]?.message);
+    }
+
+    const sanitizedContent = sanitizeText(parsed.data.content);
+
+    const result = await pool.query(
+      `INSERT INTO feed_comments (post_id, guest_id, content)
+       VALUES ($1, $2, $3)
+       RETURNING id, content, created_at`,
+      [postId, session.guestId, sanitizedContent]
+    );
+
+    // Increment comment count
+    await pool.query(
+      `UPDATE feed_posts SET comment_count = comment_count + 1 WHERE id = $1`,
+      [postId]
+    );
+
+    // Get guest info
+    const guestResult = await pool.query(
+      `SELECT id, first_name, last_name, display_name FROM guests WHERE id = $1`,
+      [session.guestId]
+    );
+
+    const comment = result.rows[0];
+    const guest = guestResult.rows[0];
+
+    return Response.json(
+      {
+        data: {
+          comment: {
+            id: comment.id,
+            content: comment.content,
+            guest: {
+              id: guest.id,
+              first_name: guest.first_name,
+              last_name: guest.last_name,
+              display_name: guest.display_name,
+            },
+            created_at: comment.created_at,
+          },
+        },
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/app/api/v1/w/[slug]/feed/[postId]/like/route.ts
+++ b/app/api/v1/w/[slug]/feed/[postId]/like/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest } from 'next/server';
+import { getPool } from '@/lib/db/client';
+import { validateSession } from '@/lib/session';
+import { AppError, handleApiError } from '@/lib/errors';
+
+// POST /api/v1/w/[slug]/feed/[postId]/like — toggle like
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string; postId: string }> }
+) {
+  try {
+    const { postId } = await params;
+    const pool = getPool();
+
+    // Validate guest session
+    const sessionToken = request.cookies.get('wedding_session')?.value;
+    if (!sessionToken) {
+      throw new AppError('AUTH_NOT_REGISTERED');
+    }
+
+    const session = await validateSession(pool, sessionToken);
+    if (!session) {
+      throw new AppError('AUTH_TOKEN_EXPIRED');
+    }
+
+    // Verify post exists and belongs to this wedding
+    const postResult = await pool.query(
+      `SELECT id, wedding_id, like_count, is_hidden FROM feed_posts WHERE id = $1`,
+      [postId]
+    );
+    if (postResult.rows.length === 0 || postResult.rows[0].is_hidden) {
+      throw new AppError('FEED_POST_HIDDEN');
+    }
+    if (postResult.rows[0].wedding_id !== session.weddingId) {
+      throw new AppError('AUTH_NOT_REGISTERED');
+    }
+
+    // Check if already liked
+    const existingLike = await pool.query(
+      `SELECT id FROM feed_likes WHERE post_id = $1 AND guest_id = $2`,
+      [postId, session.guestId]
+    );
+
+    let liked: boolean;
+    let likeCount: number;
+
+    if (existingLike.rows.length > 0) {
+      // Unlike
+      await pool.query(
+        `DELETE FROM feed_likes WHERE post_id = $1 AND guest_id = $2`,
+        [postId, session.guestId]
+      );
+      const updated = await pool.query(
+        `UPDATE feed_posts SET like_count = GREATEST(0, like_count - 1) WHERE id = $1 RETURNING like_count`,
+        [postId]
+      );
+      liked = false;
+      likeCount = updated.rows[0].like_count;
+    } else {
+      // Like
+      await pool.query(
+        `INSERT INTO feed_likes (post_id, guest_id) VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+        [postId, session.guestId]
+      );
+      const updated = await pool.query(
+        `UPDATE feed_posts SET like_count = like_count + 1 WHERE id = $1 RETURNING like_count`,
+        [postId]
+      );
+      liked = true;
+      likeCount = updated.rows[0].like_count;
+    }
+
+    return Response.json({
+      data: { liked, like_count: likeCount },
+    });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/app/api/v1/w/[slug]/feed/route.ts
+++ b/app/api/v1/w/[slug]/feed/route.ts
@@ -1,0 +1,219 @@
+import { NextRequest } from 'next/server';
+import { getPool } from '@/lib/db/client';
+import { validateSession } from '@/lib/session';
+import { getCdnUrl } from '@/lib/storage/r2';
+import { feedPostSchema, sanitizeText } from '@/lib/validation';
+import { AppError, handleApiError } from '@/lib/errors';
+
+// GET /api/v1/w/[slug]/feed — list posts
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  try {
+    const { slug } = await params;
+    const pool = getPool();
+
+    // Validate guest session
+    const sessionToken = request.cookies.get('wedding_session')?.value;
+    if (!sessionToken) {
+      throw new AppError('AUTH_NOT_REGISTERED');
+    }
+
+    const session = await validateSession(pool, sessionToken);
+    if (!session) {
+      throw new AppError('AUTH_TOKEN_EXPIRED');
+    }
+
+    // Verify wedding
+    const weddingResult = await pool.query(
+      `SELECT id FROM weddings WHERE slug = $1`,
+      [slug]
+    );
+    if (weddingResult.rows.length === 0) {
+      throw new AppError('WEDDING_NOT_FOUND');
+    }
+    if (weddingResult.rows[0].id !== session.weddingId) {
+      throw new AppError('AUTH_NOT_REGISTERED');
+    }
+
+    // Parse pagination
+    const url = new URL(request.url);
+    const cursor = url.searchParams.get('cursor');
+    const limit = Math.min(parseInt(url.searchParams.get('limit') || '20', 10), 100);
+
+    const conditions = ['p.wedding_id = $1', 'p.is_hidden = FALSE'];
+    const queryParams: (string | number)[] = [session.weddingId];
+    let paramIndex = 2;
+
+    if (cursor) {
+      conditions.push(`p.created_at < $${paramIndex}`);
+      queryParams.push(cursor);
+      paramIndex++;
+    }
+
+    queryParams.push(limit + 1);
+
+    const result = await pool.query(
+      `SELECT p.id, p.type, p.content, p.photo_key, p.like_count, p.comment_count,
+              p.is_pinned, p.created_at,
+              g.id as guest_id, g.first_name, g.last_name, g.display_name
+       FROM feed_posts p
+       JOIN guests g ON p.guest_id = g.id
+       WHERE ${conditions.join(' AND ')}
+       ORDER BY p.is_pinned DESC, p.created_at DESC
+       LIMIT $${paramIndex}`,
+      queryParams
+    );
+
+    const hasMore = result.rows.length > limit;
+    const rows = result.rows.slice(0, limit);
+
+    // Check if current user has liked each post
+    let likedPostIds: Set<string> = new Set();
+    if (rows.length > 0) {
+      const postIds = rows.map((r) => r.id);
+      const likesResult = await pool.query(
+        `SELECT post_id FROM feed_likes WHERE guest_id = $1 AND post_id = ANY($2)`,
+        [session.guestId, postIds]
+      );
+      likedPostIds = new Set(likesResult.rows.map((r) => r.post_id));
+    }
+
+    const posts = rows.map((row) => ({
+      id: row.id,
+      type: row.type,
+      content: row.content,
+      photo_url: row.photo_key ? getCdnUrl(row.photo_key) : null,
+      like_count: row.like_count,
+      comment_count: row.comment_count,
+      is_pinned: row.is_pinned,
+      is_liked: likedPostIds.has(row.id),
+      guest: {
+        id: row.guest_id,
+        first_name: row.first_name,
+        last_name: row.last_name,
+        display_name: row.display_name,
+      },
+      created_at: row.created_at,
+    }));
+
+    return Response.json({
+      data: {
+        items: posts,
+        next_cursor: hasMore && rows.length > 0 ? rows[rows.length - 1].created_at : null,
+        has_more: hasMore,
+      },
+    });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}
+
+// POST /api/v1/w/[slug]/feed — create a post
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  try {
+    const { slug } = await params;
+    const pool = getPool();
+
+    // Validate guest session
+    const sessionToken = request.cookies.get('wedding_session')?.value;
+    if (!sessionToken) {
+      throw new AppError('AUTH_NOT_REGISTERED');
+    }
+
+    const session = await validateSession(pool, sessionToken);
+    if (!session) {
+      throw new AppError('AUTH_TOKEN_EXPIRED');
+    }
+
+    // Check social feed is enabled
+    const weddingResult = await pool.query(
+      `SELECT id, package_config FROM weddings WHERE slug = $1`,
+      [slug]
+    );
+    if (weddingResult.rows.length === 0) {
+      throw new AppError('WEDDING_NOT_FOUND');
+    }
+    if (weddingResult.rows[0].id !== session.weddingId) {
+      throw new AppError('AUTH_NOT_REGISTERED');
+    }
+
+    const pkgConfig = weddingResult.rows[0].package_config || {};
+    if (pkgConfig.social_feed === false) {
+      throw new AppError('BILLING_FEATURE_LOCKED');
+    }
+
+    // Validate body
+    const body = await request.json();
+    const parsed = feedPostSchema.safeParse(body);
+    if (!parsed.success) {
+      throw new AppError('VALIDATION_ERROR', parsed.error.issues[0]?.message || 'Invalid post');
+    }
+
+    const { type, content, photo_upload_id } = parsed.data;
+
+    // Sanitize content
+    const sanitizedContent = content ? sanitizeText(content) : null;
+
+    // If photo post, get the storage key from the upload
+    let photoKey: string | null = null;
+    if (photo_upload_id) {
+      const uploadResult = await pool.query(
+        `SELECT storage_key FROM uploads
+         WHERE id = $1 AND wedding_id = $2 AND guest_id = $3 AND status = 'ready'`,
+        [photo_upload_id, session.weddingId, session.guestId]
+      );
+      if (uploadResult.rows.length === 0) {
+        throw new AppError('VALIDATION_ERROR', 'Photo not found');
+      }
+      photoKey = uploadResult.rows[0].storage_key;
+    }
+
+    const result = await pool.query(
+      `INSERT INTO feed_posts (wedding_id, guest_id, type, content, photo_key)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING id, type, content, photo_key, like_count, comment_count, is_pinned, created_at`,
+      [session.weddingId, session.guestId, type, sanitizedContent, photoKey]
+    );
+
+    const post = result.rows[0];
+
+    // Get guest info for response
+    const guestResult = await pool.query(
+      `SELECT id, first_name, last_name, display_name FROM guests WHERE id = $1`,
+      [session.guestId]
+    );
+    const guest = guestResult.rows[0];
+
+    return Response.json(
+      {
+        data: {
+          post: {
+            id: post.id,
+            type: post.type,
+            content: post.content,
+            photo_url: post.photo_key ? getCdnUrl(post.photo_key) : null,
+            like_count: post.like_count,
+            comment_count: post.comment_count,
+            is_pinned: post.is_pinned,
+            is_liked: false,
+            guest: {
+              id: guest.id,
+              first_name: guest.first_name,
+              last_name: guest.last_name,
+              display_name: guest.display_name,
+            },
+            created_at: post.created_at,
+          },
+        },
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/app/api/v1/w/[slug]/media/[guestId]/route.ts
+++ b/app/api/v1/w/[slug]/media/[guestId]/route.ts
@@ -1,0 +1,146 @@
+import { NextRequest } from 'next/server';
+import { getPool } from '@/lib/db/client';
+import { validateSession } from '@/lib/session';
+import { getCdnUrl } from '@/lib/storage/r2';
+import { AppError, handleApiError } from '@/lib/errors';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string; guestId: string }> }
+) {
+  try {
+    const { slug, guestId } = await params;
+    const pool = getPool();
+
+    // Validate guest session
+    const sessionToken = request.cookies.get('wedding_session')?.value;
+    if (!sessionToken) {
+      throw new AppError('AUTH_NOT_REGISTERED');
+    }
+
+    const session = await validateSession(pool, sessionToken);
+    if (!session) {
+      throw new AppError('AUTH_TOKEN_EXPIRED');
+    }
+
+    // Verify wedding
+    const weddingResult = await pool.query(
+      `SELECT id FROM weddings WHERE slug = $1`,
+      [slug]
+    );
+    if (weddingResult.rows.length === 0) {
+      throw new AppError('WEDDING_NOT_FOUND');
+    }
+    if (weddingResult.rows[0].id !== session.weddingId) {
+      throw new AppError('AUTH_NOT_REGISTERED');
+    }
+
+    // Parse query params
+    const url = new URL(request.url);
+    const typeFilter = url.searchParams.get('type');
+    const eventId = url.searchParams.get('event_id');
+    const cursor = url.searchParams.get('cursor');
+    const limit = Math.min(parseInt(url.searchParams.get('limit') || '20', 10), 100);
+
+    // Build query for uploads
+    const conditions: string[] = ['u.wedding_id = $1', 'u.guest_id = $2', "u.status = 'ready'"];
+    const queryParams: (string | number)[] = [session.weddingId, guestId];
+    let paramIndex = 3;
+
+    if (typeFilter && ['photo', 'video'].includes(typeFilter)) {
+      conditions.push(`u.type = $${paramIndex}`);
+      queryParams.push(typeFilter);
+      paramIndex++;
+    }
+
+    if (eventId) {
+      conditions.push(`u.event_id = $${paramIndex}`);
+      queryParams.push(eventId);
+      paramIndex++;
+    }
+
+    if (cursor) {
+      conditions.push(`u.created_at < $${paramIndex}`);
+      queryParams.push(cursor);
+      paramIndex++;
+    }
+
+    queryParams.push(limit + 1);
+
+    const uploadsQuery = `
+      SELECT u.id, u.type, u.storage_key, u.thumbnail_key, u.filter_applied,
+             u.duration_ms, u.created_at, e.name as event_name
+      FROM uploads u
+      LEFT JOIN events e ON u.event_id = e.id
+      WHERE ${conditions.join(' AND ')}
+      ORDER BY u.created_at DESC
+      LIMIT $${paramIndex}
+    `;
+
+    const uploadsResult = await pool.query(uploadsQuery, queryParams);
+
+    // Also get AI portraits for this guest
+    let portraits: typeof uploadsResult.rows = [];
+    if (!typeFilter || typeFilter === 'portrait') {
+      const portraitConditions: string[] = [
+        'a.wedding_id = $1',
+        'a.guest_id = $2',
+        "a.type = 'portrait'",
+        "a.status = 'completed'",
+        'a.output_key IS NOT NULL',
+      ];
+      const portraitParams: (string | number)[] = [session.weddingId, guestId];
+      let pIdx = 3;
+
+      if (cursor) {
+        portraitConditions.push(`a.created_at < $${pIdx}`);
+        portraitParams.push(cursor);
+        pIdx++;
+      }
+
+      portraitParams.push(limit + 1);
+
+      const portraitQuery = `
+        SELECT a.id, 'portrait' as type, a.output_key as storage_key,
+               a.output_key as thumbnail_key, a.style_id as filter_applied,
+               NULL as duration_ms, a.created_at, NULL as event_name
+        FROM ai_jobs a
+        WHERE ${portraitConditions.join(' AND ')}
+        ORDER BY a.created_at DESC
+        LIMIT $${pIdx}
+      `;
+
+      const portraitResult = await pool.query(portraitQuery, portraitParams);
+      portraits = portraitResult.rows;
+    }
+
+    // Merge and sort uploads + portraits
+    const allItems = [...uploadsResult.rows, ...portraits]
+      .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+      .slice(0, limit + 1);
+
+    const hasMore = allItems.length > limit;
+    const items = allItems.slice(0, limit);
+
+    const mediaItems = items.map((row) => ({
+      id: row.id,
+      type: row.type as 'photo' | 'video' | 'portrait',
+      url: getCdnUrl(row.storage_key),
+      thumbnail_url: row.thumbnail_key ? getCdnUrl(row.thumbnail_key) : getCdnUrl(row.storage_key),
+      event_name: row.event_name || null,
+      filter_applied: row.filter_applied || null,
+      duration_ms: row.duration_ms || null,
+      created_at: row.created_at,
+    }));
+
+    return Response.json({
+      data: {
+        items: mediaItems,
+        next_cursor: hasMore && items.length > 0 ? items[items.length - 1].created_at : null,
+        has_more: hasMore,
+      },
+    });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/app/api/v1/w/[slug]/upload/complete/route.ts
+++ b/app/api/v1/w/[slug]/upload/complete/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { getPool } from '@/lib/db/client';
+import { validateSession } from '@/lib/session';
+import { getCdnUrl, getThumbnailKey } from '@/lib/storage/r2';
+import { AppError, handleApiError } from '@/lib/errors';
+
+const completeSchema = z.object({
+  upload_id: z.string().uuid(),
+  storage_key: z.string().min(1),
+  filter_applied: z.string().max(100).optional(),
+  prompt_answered: z.string().max(500).optional(),
+  width: z.number().int().positive().optional(),
+  height: z.number().int().positive().optional(),
+  duration_ms: z.number().int().positive().optional(),
+});
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  try {
+    const { slug } = await params;
+    const pool = getPool();
+
+    // Validate guest session
+    const sessionToken = request.cookies.get('wedding_session')?.value;
+    if (!sessionToken) {
+      throw new AppError('AUTH_NOT_REGISTERED');
+    }
+
+    const session = await validateSession(pool, sessionToken);
+    if (!session) {
+      throw new AppError('AUTH_TOKEN_EXPIRED');
+    }
+
+    // Validate request body
+    const body = await request.json();
+    const parsed = completeSchema.safeParse(body);
+    if (!parsed.success) {
+      throw new AppError('VALIDATION_ERROR', parsed.error.issues[0]?.message);
+    }
+
+    const { upload_id, storage_key, filter_applied, prompt_answered, width, height, duration_ms } = parsed.data;
+
+    // Verify the upload belongs to this guest and wedding
+    const uploadResult = await pool.query(
+      `SELECT id, wedding_id, guest_id, status FROM uploads WHERE id = $1`,
+      [upload_id]
+    );
+
+    if (uploadResult.rows.length === 0) {
+      throw new AppError('VALIDATION_ERROR', 'Upload not found');
+    }
+
+    const upload = uploadResult.rows[0];
+    if (upload.wedding_id !== session.weddingId || upload.guest_id !== session.guestId) {
+      throw new AppError('AUTH_NOT_REGISTERED');
+    }
+
+    if (upload.status === 'ready') {
+      throw new AppError('VALIDATION_ERROR', 'Upload already completed');
+    }
+
+    // Generate thumbnail key
+    const thumbnailKey = getThumbnailKey(storage_key);
+
+    // Update upload to ready status
+    const result = await pool.query(
+      `UPDATE uploads
+       SET status = 'ready',
+           storage_key = $1,
+           thumbnail_key = $2,
+           filter_applied = $3,
+           prompt_answered = $4,
+           width = $5,
+           height = $6,
+           duration_ms = $7
+       WHERE id = $8
+       RETURNING *`,
+      [storage_key, thumbnailKey, filter_applied || null, prompt_answered || null, width || null, height || null, duration_ms || null, upload_id]
+    );
+
+    const updated = result.rows[0];
+
+    // Update wedding storage usage
+    await pool.query(
+      `UPDATE weddings SET storage_used_bytes = storage_used_bytes + $1 WHERE id = $2`,
+      [updated.size_bytes || 0, session.weddingId]
+    );
+
+    return Response.json({
+      data: {
+        upload: {
+          id: updated.id,
+          type: updated.type,
+          url: getCdnUrl(updated.storage_key),
+          thumbnail_url: getCdnUrl(thumbnailKey),
+          status: updated.status,
+          created_at: updated.created_at,
+        },
+      },
+    });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/app/api/v1/w/[slug]/upload/presign/route.ts
+++ b/app/api/v1/w/[slug]/upload/presign/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest } from 'next/server';
+import { v4 as uuidv4 } from 'uuid';
+import { getPool } from '@/lib/db/client';
+import { validateSession } from '@/lib/session';
+import { generatePresignedPutUrl } from '@/lib/storage/r2';
+import { uploadPresignSchema } from '@/lib/validation';
+import { AppError, handleApiError } from '@/lib/errors';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  try {
+    const { slug } = await params;
+    const pool = getPool();
+
+    // Validate guest session
+    const sessionToken = request.cookies.get('wedding_session')?.value;
+    if (!sessionToken) {
+      throw new AppError('AUTH_NOT_REGISTERED');
+    }
+
+    const session = await validateSession(pool, sessionToken);
+    if (!session) {
+      throw new AppError('AUTH_TOKEN_EXPIRED');
+    }
+
+    // Verify wedding slug matches session
+    const weddingResult = await pool.query(
+      `SELECT id, status FROM weddings WHERE slug = $1`,
+      [slug]
+    );
+    if (weddingResult.rows.length === 0) {
+      throw new AppError('WEDDING_NOT_FOUND');
+    }
+    const wedding = weddingResult.rows[0];
+    if (wedding.id !== session.weddingId) {
+      throw new AppError('AUTH_NOT_REGISTERED');
+    }
+    if (wedding.status === 'archived') {
+      throw new AppError('WEDDING_INACTIVE');
+    }
+
+    // Validate request body
+    const body = await request.json();
+    const parsed = uploadPresignSchema.safeParse(body);
+    if (!parsed.success) {
+      throw new AppError('VALIDATION_ERROR', parsed.error.issues[0]?.message);
+    }
+
+    const { type, mime_type, size_bytes, event_id } = parsed.data;
+
+    // If event_id provided, verify it belongs to this wedding
+    if (event_id) {
+      const eventResult = await pool.query(
+        `SELECT id FROM events WHERE id = $1 AND wedding_id = $2`,
+        [event_id, session.weddingId]
+      );
+      if (eventResult.rows.length === 0) {
+        throw new AppError('VALIDATION_ERROR', 'Event not found');
+      }
+    }
+
+    const uploadId = uuidv4();
+
+    // Create upload record in pending state
+    await pool.query(
+      `INSERT INTO uploads (id, wedding_id, guest_id, event_id, type, storage_key, mime_type, size_bytes, status)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'pending')`,
+      [uploadId, session.weddingId, session.guestId, event_id || null, type, '', mime_type, size_bytes]
+    );
+
+    // Generate presigned URL
+    const presigned = await generatePresignedPutUrl({
+      weddingId: session.weddingId,
+      uploadId,
+      contentType: mime_type,
+      contentLength: size_bytes,
+    });
+
+    // Update upload with storage key
+    await pool.query(
+      `UPDATE uploads SET storage_key = $1, status = 'uploading' WHERE id = $2`,
+      [presigned.key, uploadId]
+    );
+
+    return Response.json({
+      data: {
+        upload_id: uploadId,
+        presigned_url: presigned.url,
+        storage_key: presigned.key,
+        expires_at: presigned.expiresAt.toISOString(),
+        multipart: presigned.multipart || false,
+      },
+    });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/app/w/[slug]/faq/page.tsx
+++ b/app/w/[slug]/faq/page.tsx
@@ -1,37 +1,210 @@
 'use client';
 
 import BottomNav from '@/components/guest/BottomNav';
+import { useWedding } from '@/components/WeddingProvider';
+import { useState, useRef, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+
+interface ChatMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+const QUICK_QUESTIONS = [
+  "What's the dress code?",
+  'Where do I park?',
+  'Is there a plus one?',
+  'What time should I arrive?',
+  'Where is the venue?',
+  'Is it indoors or outdoors?',
+];
 
 export default function FaqPage() {
+  const { config, guest, slug, isAuthenticated, isLoading } = useWedding();
+  const router = useRouter();
+
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [inputText, setInputText] = useState('');
+  const [sending, setSending] = useState(false);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      router.replace(`/w/${slug}`);
+    }
+  }, [isLoading, isAuthenticated, router, slug]);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const askQuestion = async (question: string) => {
+    if (!question.trim() || sending) return;
+
+    const userMsg: ChatMessage = { id: `u-${Date.now()}`, role: 'user', content: question.trim() };
+    setMessages((prev) => [...prev, userMsg]);
+    setInputText('');
+    setSending(true);
+
+    try {
+      const res = await fetch(`/api/v1/w/${slug}/faq`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question: question.trim() }),
+      });
+      const data = await res.json();
+
+      const reply: ChatMessage = {
+        id: `a-${Date.now()}`,
+        role: 'assistant',
+        content: data.data?.answer || data.error?.message || 'Something went wrong. Please try again.',
+      };
+      setMessages((prev) => [...prev, reply]);
+    } catch {
+      setMessages((prev) => [
+        ...prev,
+        { id: `e-${Date.now()}`, role: 'assistant', content: "I'm having trouble connecting. Please try again in a moment." },
+      ]);
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    askQuestion(inputText);
+  };
+
+  if (isLoading || !guest) {
+    return (
+      <div className="pb-24 px-5 pt-8 max-w-lg mx-auto">
+        <div className="skeleton h-8 w-40 mb-6" />
+        <div className="skeleton h-20 w-full mb-3 rounded-xl" />
+        <BottomNav />
+      </div>
+    );
+  }
+
+  const coupleName = config?.couple_names
+    ? `${config.couple_names.name1} & ${config.couple_names.name2}`
+    : 'the couple';
+
   return (
-    <div className="pb-24 px-5 pt-8 max-w-lg mx-auto">
-      <h1
-        className="text-2xl font-medium mb-6"
-        style={{
-          fontFamily: 'var(--font-display)',
-          color: 'var(--text-primary)',
-        }}
-      >
-        Questions?
-      </h1>
-      <p className="text-sm mb-4" style={{ color: 'var(--text-secondary)' }}>
-        Ask anything about the wedding and get an instant answer.
-      </p>
-      <div className="flex flex-wrap gap-2 mb-6">
-        {['What\'s the dress code?', 'Where do I park?', 'Is there a plus one?'].map((q) => (
+    <div className="pb-24 pt-8 max-w-lg mx-auto flex flex-col" style={{ minHeight: 'calc(100vh - 80px)' }}>
+      <div className="px-5">
+        <h1
+          className="text-2xl font-medium mb-2"
+          style={{ fontFamily: 'var(--font-display)', color: 'var(--text-primary)' }}
+        >
+          Questions?
+        </h1>
+        <p className="text-sm mb-4" style={{ color: 'var(--text-secondary)' }}>
+          Ask anything about {coupleName}&apos;s wedding and get an instant answer.
+        </p>
+      </div>
+
+      {/* Chat Messages */}
+      <div className="flex-1 overflow-y-auto px-5 space-y-3">
+        {messages.length === 0 && (
+          <div className="text-center py-8">
+            <p className="text-4xl mb-3">&#128173;</p>
+            <p className="text-base font-medium mb-4" style={{ fontFamily: 'var(--font-display)', color: 'var(--text-primary)' }}>
+              How can I help?
+            </p>
+            <div className="flex flex-wrap gap-2 justify-center">
+              {QUICK_QUESTIONS.map((q) => (
+                <button
+                  key={q}
+                  onClick={() => askQuestion(q)}
+                  className="px-4 py-2 rounded-full text-sm"
+                  style={{ background: 'rgba(196, 112, 75, 0.08)', color: 'var(--color-terracotta)' }}
+                >
+                  {q}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {messages.map((msg) => (
+          <div key={msg.id} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+            <div
+              className="max-w-[85%] rounded-2xl px-4 py-3"
+              style={{
+                background: msg.role === 'user' ? 'var(--color-terracotta)' : 'var(--bg-pure-white)',
+                color: msg.role === 'user' ? 'white' : 'var(--text-primary)',
+                boxShadow: msg.role === 'assistant' ? 'var(--shadow-soft)' : 'none',
+                border: msg.role === 'assistant' ? '1px solid var(--border-light)' : 'none',
+              }}
+            >
+              <p className="text-sm whitespace-pre-wrap">{msg.content}</p>
+            </div>
+          </div>
+        ))}
+
+        {sending && (
+          <div className="flex justify-start">
+            <div className="rounded-2xl px-4 py-3" style={{ background: 'var(--bg-pure-white)', boxShadow: 'var(--shadow-soft)', border: '1px solid var(--border-light)' }}>
+              <div className="flex gap-1">
+                <div className="w-2 h-2 rounded-full animate-bounce" style={{ background: 'var(--text-tertiary)', animationDelay: '0ms' }} />
+                <div className="w-2 h-2 rounded-full animate-bounce" style={{ background: 'var(--text-tertiary)', animationDelay: '150ms' }} />
+                <div className="w-2 h-2 rounded-full animate-bounce" style={{ background: 'var(--text-tertiary)', animationDelay: '300ms' }} />
+              </div>
+            </div>
+          </div>
+        )}
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Input Bar */}
+      <div className="px-5 pt-3 pb-2">
+        <form onSubmit={handleSubmit} className="flex gap-2">
+          <input
+            type="text"
+            value={inputText}
+            onChange={(e) => setInputText(e.target.value)}
+            placeholder="Ask a question..."
+            className="flex-1 rounded-full px-4 py-3 text-sm"
+            style={{ background: 'var(--bg-pure-white)', border: '1px solid var(--border-medium)', color: 'var(--text-primary)' }}
+            disabled={sending}
+          />
           <button
-            key={q}
-            className="px-4 py-2 rounded-full text-sm"
+            type="submit"
+            disabled={!inputText.trim() || sending}
+            className="w-11 h-11 rounded-full flex items-center justify-center flex-shrink-0"
             style={{
-              background: 'rgba(196, 112, 75, 0.08)',
-              color: 'var(--color-terracotta)',
-              fontFamily: 'var(--font-body)',
+              background: inputText.trim() ? 'var(--color-terracotta-gradient)' : 'var(--border-light)',
+              color: inputText.trim() ? 'white' : 'var(--text-tertiary)',
+              border: 'none',
             }}
           >
-            {q}
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <line x1="22" y1="2" x2="11" y2="13" />
+              <polygon points="22 2 15 22 11 13 2 9 22 2" />
+            </svg>
           </button>
-        ))}
+        </form>
+
+        {messages.length > 0 && messages.length < 6 && (
+          <div className="flex gap-2 mt-2 overflow-x-auto pb-1">
+            {QUICK_QUESTIONS.filter((q) => !messages.some((m) => m.role === 'user' && m.content === q))
+              .slice(0, 3)
+              .map((q) => (
+                <button
+                  key={q}
+                  onClick={() => askQuestion(q)}
+                  className="px-3 py-1.5 rounded-full text-xs whitespace-nowrap flex-shrink-0"
+                  style={{ background: 'rgba(196, 112, 75, 0.08)', color: 'var(--color-terracotta)' }}
+                  disabled={sending}
+                >
+                  {q}
+                </button>
+              ))}
+          </div>
+        )}
       </div>
+
       <BottomNav />
     </div>
   );

--- a/app/w/[slug]/feed/page.tsx
+++ b/app/w/[slug]/feed/page.tsx
@@ -2,11 +2,124 @@
 
 import { useWedding } from '@/components/WeddingProvider';
 import BottomNav from '@/components/guest/BottomNav';
+import { useEffect, useState, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+
+interface FeedPost {
+  id: string;
+  type: 'text' | 'photo' | 'memory';
+  content: string | null;
+  photo_url: string | null;
+  like_count: number;
+  comment_count: number;
+  is_pinned: boolean;
+  is_liked: boolean;
+  guest: {
+    id: string;
+    first_name: string;
+    last_name: string;
+    display_name: string;
+  };
+  created_at: string;
+}
 
 export default function FeedPage() {
-  const { guest, isLoading } = useWedding();
+  const { config, guest, slug, isAuthenticated, isLoading } = useWedding();
+  const router = useRouter();
 
-  if (isLoading) {
+  const [posts, setPosts] = useState<FeedPost[]>([]);
+  const [loadingPosts, setLoadingPosts] = useState(true);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [showCompose, setShowCompose] = useState(false);
+  const [composeText, setComposeText] = useState('');
+  const [composeType, setComposeType] = useState<'text' | 'memory'>('text');
+  const [posting, setPosting] = useState(false);
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      router.replace(`/w/${slug}`);
+    }
+  }, [isLoading, isAuthenticated, router, slug]);
+
+  const fetchPosts = useCallback(
+    async (cursor?: string | null) => {
+      try {
+        const params = new URLSearchParams({ limit: '20' });
+        if (cursor) params.set('cursor', cursor);
+
+        const res = await fetch(`/api/v1/w/${slug}/feed?${params.toString()}`);
+        const data = await res.json();
+
+        if (data.data) {
+          if (cursor) {
+            setPosts((prev) => [...prev, ...data.data.items]);
+          } else {
+            setPosts(data.data.items);
+          }
+          setNextCursor(data.data.next_cursor);
+        }
+      } catch (err) {
+        console.error('Failed to fetch feed:', err);
+      }
+    },
+    [slug]
+  );
+
+  useEffect(() => {
+    if (!guest) return;
+    setLoadingPosts(true);
+    fetchPosts().finally(() => setLoadingPosts(false));
+  }, [guest, fetchPosts]);
+
+  const handlePost = async () => {
+    if (!composeText.trim() || posting) return;
+    setPosting(true);
+
+    try {
+      const res = await fetch(`/api/v1/w/${slug}/feed`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type: composeType,
+          content: composeText.trim(),
+        }),
+      });
+
+      const data = await res.json();
+      if (data.data?.post) {
+        setPosts((prev) => [data.data.post, ...prev]);
+        setComposeText('');
+        setShowCompose(false);
+      }
+    } catch (err) {
+      console.error('Failed to create post:', err);
+    } finally {
+      setPosting(false);
+    }
+  };
+
+  const handleLike = async (postId: string) => {
+    try {
+      const res = await fetch(`/api/v1/w/${slug}/feed/${postId}/like`, {
+        method: 'POST',
+      });
+      const data = await res.json();
+
+      if (data.data) {
+        setPosts((prev) =>
+          prev.map((p) =>
+            p.id === postId
+              ? { ...p, is_liked: data.data.liked, like_count: data.data.like_count }
+              : p
+          )
+        );
+      }
+    } catch (err) {
+      console.error('Failed to toggle like:', err);
+    }
+  };
+
+  if (isLoading || !guest) {
     return (
       <div className="pb-24 px-5 pt-8 max-w-lg mx-auto">
         <div className="skeleton h-8 w-32 mb-6" />
@@ -17,32 +130,227 @@ export default function FeedPage() {
     );
   }
 
+  const formatTime = (dateStr: string) => {
+    const date = new Date(dateStr);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMin = Math.floor(diffMs / 60000);
+    if (diffMin < 1) return 'Just now';
+    if (diffMin < 60) return `${diffMin}m ago`;
+    const diffHr = Math.floor(diffMin / 60);
+    if (diffHr < 24) return `${diffHr}h ago`;
+    const diffDays = Math.floor(diffHr / 24);
+    return `${diffDays}d ago`;
+  };
+
+  const getInitials = (name: string) =>
+    name.split(' ').map((w) => w[0]).join('').toUpperCase().slice(0, 2);
+
+  const getAvatarColor = (name: string) => {
+    const colors = ['#C4704B', '#2B5F8A', '#7A8B5C', '#D4A853', '#E8865A'];
+    const index = name.split('').reduce((acc, c) => acc + c.charCodeAt(0), 0) % colors.length;
+    return colors[index];
+  };
+
   return (
     <div className="pb-24 px-5 pt-8 max-w-lg mx-auto">
-      <h1
-        className="text-2xl font-medium mb-6"
-        style={{
-          fontFamily: 'var(--font-display)',
-          color: 'var(--text-primary)',
-        }}
-      >
-        Feed
-      </h1>
-      <div className="text-center py-16">
-        <p className="text-5xl mb-4">&#128172;</p>
-        <p
-          className="text-lg font-medium mb-2"
+      <div className="flex items-center justify-between mb-6">
+        <h1
+          className="text-2xl font-medium"
+          style={{ fontFamily: 'var(--font-display)', color: 'var(--text-primary)' }}
+        >
+          Feed
+        </h1>
+        <button
+          onClick={() => setShowCompose(true)}
+          className="px-4 py-2 text-sm rounded-full font-semibold"
           style={{
-            fontFamily: 'var(--font-display)',
-            color: 'var(--text-primary)',
+            background: 'var(--color-terracotta-gradient)',
+            color: 'white',
+            border: 'none',
           }}
         >
-          No posts yet
-        </p>
-        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
-          Be the first to share a moment!
-        </p>
+          + Post
+        </button>
       </div>
+
+      {/* Compose Card */}
+      {showCompose && (
+        <div
+          className="p-4 mb-4"
+          style={{
+            background: 'var(--bg-pure-white)',
+            borderRadius: '16px',
+            boxShadow: 'var(--shadow-soft)',
+            border: '1px solid var(--border-light)',
+          }}
+        >
+          <div className="flex gap-2 mb-3">
+            {(['text', 'memory'] as const).map((t) => (
+              <button
+                key={t}
+                onClick={() => setComposeType(t)}
+                className="px-3 py-1 rounded-full text-xs font-medium"
+                style={{
+                  background: composeType === t ? 'var(--color-terracotta)' : 'transparent',
+                  color: composeType === t ? 'white' : 'var(--text-secondary)',
+                  border: composeType === t ? 'none' : '1px solid var(--border-light)',
+                }}
+              >
+                {t === 'text' ? 'Share a moment' : 'Favorite memory'}
+              </button>
+            ))}
+          </div>
+          <textarea
+            value={composeText}
+            onChange={(e) => setComposeText(e.target.value)}
+            placeholder={
+              composeType === 'memory'
+                ? `My favorite story about ${config?.couple_names?.name1 || 'the couple'}...`
+                : 'Share a moment from the celebration...'
+            }
+            className="w-full resize-none rounded-xl p-3 text-sm"
+            style={{
+              background: 'var(--bg-soft-cream)',
+              color: 'var(--text-primary)',
+              border: '1px solid var(--border-light)',
+              fontFamily: 'var(--font-body)',
+              minHeight: '80px',
+            }}
+            maxLength={500}
+          />
+          <div className="flex justify-between items-center mt-2">
+            <span className="text-xs" style={{ color: 'var(--text-tertiary)' }}>
+              {composeText.length}/500
+            </span>
+            <div className="flex gap-2">
+              <button
+                onClick={() => { setShowCompose(false); setComposeText(''); }}
+                className="px-4 py-2 text-sm rounded-full"
+                style={{ color: 'var(--text-secondary)' }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handlePost}
+                disabled={!composeText.trim() || posting}
+                className="px-4 py-2 text-sm rounded-full font-medium"
+                style={{
+                  background: composeText.trim() ? 'var(--color-terracotta-gradient)' : 'var(--border-light)',
+                  color: composeText.trim() ? 'white' : 'var(--text-tertiary)',
+                  border: 'none',
+                }}
+              >
+                {posting ? 'Posting...' : 'Post'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Posts */}
+      {loadingPosts ? (
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="skeleton h-24 w-full rounded-xl" />
+          ))}
+        </div>
+      ) : posts.length === 0 ? (
+        <div className="text-center py-16">
+          <p className="text-5xl mb-4">&#128172;</p>
+          <p className="text-lg font-medium mb-2" style={{ fontFamily: 'var(--font-display)', color: 'var(--text-primary)' }}>
+            No posts yet
+          </p>
+          <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
+            Be the first to share a moment!
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {posts.map((post) => (
+            <div
+              key={post.id}
+              className="rounded-2xl p-4"
+              style={{
+                background: 'var(--bg-pure-white)',
+                boxShadow: 'var(--shadow-soft)',
+                border: post.is_pinned ? '1px solid var(--color-golden)' : '1px solid var(--border-light)',
+              }}
+            >
+              <div className="flex items-center gap-3 mb-3">
+                <div
+                  className="w-9 h-9 rounded-full flex items-center justify-center text-white text-xs font-semibold flex-shrink-0"
+                  style={{ background: getAvatarColor(post.guest.display_name) }}
+                >
+                  {getInitials(post.guest.display_name)}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium truncate" style={{ color: 'var(--text-primary)' }}>
+                    {post.guest.display_name}
+                  </p>
+                  <p className="text-xs" style={{ color: 'var(--text-tertiary)' }}>
+                    {formatTime(post.created_at)}
+                    {post.type === 'memory' && ' · Favorite memory'}
+                    {post.is_pinned && ' · Pinned'}
+                  </p>
+                </div>
+              </div>
+
+              {post.content && (
+                <p
+                  className="text-sm mb-3 whitespace-pre-wrap"
+                  style={{
+                    color: 'var(--text-primary)',
+                    fontFamily: post.type === 'memory' ? 'var(--font-display)' : 'var(--font-body)',
+                    fontStyle: post.type === 'memory' ? 'italic' : 'normal',
+                  }}
+                >
+                  {post.content}
+                </p>
+              )}
+
+              {post.photo_url && (
+                <div className="rounded-xl overflow-hidden mb-3">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img src={post.photo_url} alt="" className="w-full" loading="lazy" />
+                </div>
+              )}
+
+              <div className="flex items-center gap-4">
+                <button
+                  onClick={() => handleLike(post.id)}
+                  className="flex items-center gap-1.5 text-sm"
+                  style={{ color: post.is_liked ? '#E53E3E' : 'var(--text-tertiary)' }}
+                >
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill={post.is_liked ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="2">
+                    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+                  </svg>
+                  {post.like_count > 0 && post.like_count}
+                </button>
+                <button className="flex items-center gap-1.5 text-sm" style={{ color: 'var(--text-tertiary)' }}>
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                    <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+                  </svg>
+                  {post.comment_count > 0 && post.comment_count}
+                </button>
+              </div>
+            </div>
+          ))}
+
+          {nextCursor && (
+            <div className="text-center mt-4">
+              <button
+                onClick={() => fetchPosts(nextCursor)}
+                className="px-6 py-2 rounded-full text-sm font-medium"
+                style={{ background: 'rgba(196, 112, 75, 0.08)', color: 'var(--color-terracotta)' }}
+              >
+                Load more
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
       <BottomNav />
     </div>
   );

--- a/app/w/[slug]/gallery/page.tsx
+++ b/app/w/[slug]/gallery/page.tsx
@@ -2,18 +2,96 @@
 
 import { useWedding } from '@/components/WeddingProvider';
 import BottomNav from '@/components/guest/BottomNav';
-import { useEffect } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
+import type { MediaItem } from '@/lib/types/api';
+
+type FilterTab = 'all' | 'photo' | 'video' | 'portrait';
 
 export default function GalleryPage() {
   const { guest, slug, isAuthenticated, isLoading } = useWedding();
   const router = useRouter();
+
+  const [activeTab, setActiveTab] = useState<FilterTab>('all');
+  const [items, setItems] = useState<MediaItem[]>([]);
+  const [loadingMedia, setLoadingMedia] = useState(true);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [counts, setCounts] = useState({ photos: 0, videos: 0, portraits: 0 });
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
       router.replace(`/w/${slug}`);
     }
   }, [isLoading, isAuthenticated, router, slug]);
+
+  const fetchMedia = useCallback(
+    async (tab: FilterTab, cursor?: string | null) => {
+      if (!guest) return;
+
+      const params = new URLSearchParams();
+      if (tab !== 'all') params.set('type', tab);
+      if (cursor) params.set('cursor', cursor);
+      params.set('limit', '30');
+
+      try {
+        const res = await fetch(
+          `/api/v1/w/${slug}/media/${guest.id}?${params.toString()}`
+        );
+        const data = await res.json();
+
+        if (data.data) {
+          if (cursor) {
+            setItems((prev) => [...prev, ...data.data.items]);
+          } else {
+            setItems(data.data.items);
+          }
+          setNextCursor(data.data.next_cursor);
+        }
+      } catch (err) {
+        console.error('Failed to fetch media:', err);
+      }
+    },
+    [guest, slug]
+  );
+
+  // Fetch counts on mount
+  useEffect(() => {
+    if (!guest) return;
+
+    const fetchCounts = async () => {
+      try {
+        const [photos, videos, portraits] = await Promise.all(
+          ['photo', 'video', 'portrait'].map(async (type) => {
+            const res = await fetch(
+              `/api/v1/w/${slug}/media/${guest.id}?type=${type}&limit=1`
+            );
+            const data = await res.json();
+            return data.data?.items?.length || 0;
+          })
+        );
+        setCounts({ photos, videos, portraits });
+      } catch {
+        // Counts are best-effort
+      }
+    };
+
+    fetchCounts();
+  }, [guest, slug]);
+
+  // Fetch media when tab changes
+  useEffect(() => {
+    if (!guest) return;
+    setLoadingMedia(true);
+    fetchMedia(activeTab).finally(() => setLoadingMedia(false));
+  }, [activeTab, guest, fetchMedia]);
+
+  const loadMore = async () => {
+    if (!nextCursor || loadingMore) return;
+    setLoadingMore(true);
+    await fetchMedia(activeTab, nextCursor);
+    setLoadingMore(false);
+  };
 
   if (isLoading || !guest) {
     return (
@@ -28,6 +106,13 @@ export default function GalleryPage() {
       </div>
     );
   }
+
+  const tabs: { id: FilterTab; label: string }[] = [
+    { id: 'all', label: 'All' },
+    { id: 'photo', label: 'Photos' },
+    { id: 'video', label: 'Videos' },
+    { id: 'portrait', label: 'Portraits' },
+  ];
 
   return (
     <div className="pb-24 px-5 pt-8 max-w-lg mx-auto">
@@ -44,9 +129,9 @@ export default function GalleryPage() {
       {/* Stats Row */}
       <div className="flex gap-4 mb-6">
         {[
-          { label: 'Photos', count: 0 },
-          { label: 'Videos', count: 0 },
-          { label: 'Portraits', count: 0 },
+          { label: 'Photos', count: counts.photos },
+          { label: 'Videos', count: counts.videos },
+          { label: 'Portraits', count: counts.portraits },
         ].map((stat) => (
           <div key={stat.label} className="text-center">
             <p
@@ -64,40 +149,120 @@ export default function GalleryPage() {
 
       {/* Filter Tabs */}
       <div className="flex gap-2 mb-6 overflow-x-auto">
-        {['All', 'Photos', 'Videos', 'Portraits'].map((tab, i) => (
+        {tabs.map((tab) => (
           <button
-            key={tab}
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
             className="px-4 py-2 rounded-full text-sm font-medium whitespace-nowrap transition-colors"
             style={{
-              background: i === 0 ? 'var(--color-terracotta)' : 'transparent',
-              color: i === 0 ? 'white' : 'var(--text-secondary)',
+              background:
+                activeTab === tab.id ? 'var(--color-terracotta)' : 'transparent',
+              color: activeTab === tab.id ? 'white' : 'var(--text-secondary)',
               border:
-                i === 0
+                activeTab === tab.id
                   ? 'none'
                   : '1px solid var(--border-light)',
             }}
           >
-            {tab}
+            {tab.label}
           </button>
         ))}
       </div>
 
-      {/* Empty State */}
-      <div className="text-center py-16">
-        <p className="text-5xl mb-4">&#128247;</p>
-        <p
-          className="text-lg font-medium mb-2"
-          style={{
-            fontFamily: 'var(--font-display)',
-            color: 'var(--text-primary)',
-          }}
-        >
-          No memories yet
-        </p>
-        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
-          Take a photo or record a video to start building your gallery!
-        </p>
-      </div>
+      {/* Media Grid */}
+      {loadingMedia ? (
+        <div className="grid grid-cols-3 gap-[3px]">
+          {Array.from({ length: 9 }).map((_, i) => (
+            <div key={i} className="skeleton aspect-square" />
+          ))}
+        </div>
+      ) : items.length === 0 ? (
+        <div className="text-center py-16">
+          <p className="text-5xl mb-4">&#128247;</p>
+          <p
+            className="text-lg font-medium mb-2"
+            style={{
+              fontFamily: 'var(--font-display)',
+              color: 'var(--text-primary)',
+            }}
+          >
+            No memories yet
+          </p>
+          <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
+            Take a photo or record a video to start building your gallery!
+          </p>
+        </div>
+      ) : (
+        <>
+          <div className="grid grid-cols-3 gap-[3px]">
+            {items.map((item) => (
+              <div
+                key={item.id}
+                className="aspect-square relative overflow-hidden rounded-sm"
+                style={{ background: 'var(--bg-soft-cream)' }}
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={item.thumbnail_url}
+                  alt=""
+                  className="w-full h-full object-cover"
+                  loading="lazy"
+                />
+
+                {/* Video duration badge */}
+                {item.type === 'video' && item.duration_ms && (
+                  <div className="absolute bottom-1 right-1 bg-black/60 text-white text-[10px] px-1.5 py-0.5 rounded">
+                    {Math.floor(item.duration_ms / 60000)}:
+                    {String(Math.floor((item.duration_ms % 60000) / 1000)).padStart(2, '0')}
+                  </div>
+                )}
+
+                {/* Video play icon */}
+                {item.type === 'video' && (
+                  <div className="absolute inset-0 flex items-center justify-center">
+                    <div className="w-8 h-8 bg-white/80 rounded-full flex items-center justify-center">
+                      <svg width="12" height="14" viewBox="0 0 12 14" fill="var(--text-primary)">
+                        <polygon points="0,0 12,7 0,14" />
+                      </svg>
+                    </div>
+                  </div>
+                )}
+
+                {/* Portrait badge */}
+                {item.type === 'portrait' && (
+                  <div className="absolute top-1 left-1 bg-black/60 text-white text-[10px] px-1.5 py-0.5 rounded">
+                    AI
+                  </div>
+                )}
+
+                {/* Event badge */}
+                {item.event_name && (
+                  <div className="absolute top-1 right-1 bg-black/60 text-white text-[10px] px-1.5 py-0.5 rounded max-w-[80px] truncate">
+                    {item.event_name}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+
+          {/* Load More */}
+          {nextCursor && (
+            <div className="text-center mt-6">
+              <button
+                onClick={loadMore}
+                disabled={loadingMore}
+                className="px-6 py-2 rounded-full text-sm font-medium transition-colors"
+                style={{
+                  background: 'rgba(196, 112, 75, 0.08)',
+                  color: 'var(--color-terracotta)',
+                }}
+              >
+                {loadingMore ? 'Loading...' : 'Load more'}
+              </button>
+            </div>
+          )}
+        </>
+      )}
 
       <BottomNav />
     </div>

--- a/lib/ai/openai.ts
+++ b/lib/ai/openai.ts
@@ -1,0 +1,90 @@
+import OpenAI from 'openai';
+import { isTestMode } from '@/lib/env';
+
+let client: OpenAI | null = null;
+
+export function getOpenAIClient(): OpenAI {
+  if (!client) {
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey && !isTestMode()) {
+      throw new Error('OPENAI_API_KEY is not set');
+    }
+    client = new OpenAI({ apiKey: apiKey || 'test-key' });
+  }
+  return client;
+}
+
+// Portrait style definitions
+export const AI_PORTRAIT_STYLES = {
+  'castle-wedding': {
+    name: 'Castle Wedding',
+    emoji: '🏰',
+    prompt: 'Transform this photo into a dramatic royal castle wedding portrait. The subject should appear as royalty in an ornate palace setting with golden chandeliers and velvet drapes. Oil painting style, warm tones, cinematic lighting.',
+    estimatedSeconds: 30,
+  },
+  'mughal': {
+    name: 'Mughal Royalty',
+    emoji: '👑',
+    prompt: 'Transform this photo into a Mughal-era royal portrait. The subject should appear as Mughal royalty in an ornate palace with intricate Islamic geometric patterns, marble columns, and jeweled accessories. Miniature painting style with rich gold and jewel tones.',
+    estimatedSeconds: 30,
+  },
+  'bollywood-poster': {
+    name: 'Bollywood Poster',
+    emoji: '🎬',
+    prompt: 'Transform this photo into a vintage Bollywood movie poster. Dramatic lighting, bold colors, cinematic pose, with Devanagari-inspired decorative text elements and film reel borders.',
+    estimatedSeconds: 25,
+  },
+  'watercolor': {
+    name: 'Watercolor',
+    emoji: '🎨',
+    prompt: 'Transform this photo into a beautiful watercolor painting. Soft, flowing brushstrokes with delicate color washes. Artistic and dreamy, with subtle paper texture visible.',
+    estimatedSeconds: 20,
+  },
+  'renaissance': {
+    name: 'Renaissance',
+    emoji: '🖼️',
+    prompt: 'Transform this photo into an Italian Renaissance portrait in the style of Raphael or Leonardo da Vinci. Rich oil painting technique with sfumato, classical composition, dramatic chiaroscuro lighting.',
+    estimatedSeconds: 30,
+  },
+  'pop-art': {
+    name: 'Pop Art',
+    emoji: '🎯',
+    prompt: 'Transform this photo into a vibrant Andy Warhol-style pop art portrait. Bold flat colors, high contrast, halftone dots, and graphic comic-book energy.',
+    estimatedSeconds: 20,
+  },
+  'anime': {
+    name: 'Anime',
+    emoji: '✨',
+    prompt: 'Transform this photo into a beautiful Studio Ghibli-inspired anime portrait. Soft cel-shading, large expressive eyes, warm golden-hour lighting, and whimsical background details.',
+    estimatedSeconds: 20,
+  },
+  'oil-painting': {
+    name: 'Oil Painting',
+    emoji: '🖌️',
+    prompt: 'Transform this photo into a classical oil painting portrait. Rich, textured brushstrokes, warm Rembrandt-style lighting, deep shadows, and luminous highlights on a dark background.',
+    estimatedSeconds: 25,
+  },
+  'pixel-art': {
+    name: 'Pixel Art',
+    emoji: '👾',
+    prompt: 'Transform this photo into a charming 16-bit pixel art portrait. Clean pixel grid, limited retro color palette, with a nostalgic video game aesthetic.',
+    estimatedSeconds: 15,
+  },
+  'stained-glass': {
+    name: 'Stained Glass',
+    emoji: '⛪',
+    prompt: 'Transform this photo into a beautiful stained glass window design. Bold black outlines separating vibrant colored glass segments, with light appearing to shine through. Cathedral-inspired composition.',
+    estimatedSeconds: 25,
+  },
+} as const;
+
+export type PortraitStyleId = keyof typeof AI_PORTRAIT_STYLES;
+
+// Current recommended model for image generation
+export const IMAGE_MODEL = 'gpt-image-1' as const;
+// Chat model for FAQ, CSV parsing, etc.
+export const CHAT_MODEL = 'gpt-4.1' as const;
+// Smaller chat model for simpler tasks
+export const CHAT_MODEL_MINI = 'gpt-4.1-mini' as const;
+// Embedding model for FAQ
+export const EMBEDDING_MODEL = 'text-embedding-3-small' as const;

--- a/lib/db/migrations/002_phase2_capture.sql
+++ b/lib/db/migrations/002_phase2_capture.sql
@@ -1,0 +1,48 @@
+-- 002_phase2_capture.sql
+-- Phase 2: Capture features — FAQ cache table + performance indexes
+-- Run with: psql $DATABASE_URL_UNPOOLED -f lib/db/migrations/002_phase2_capture.sql
+
+-- FAQ response cache (deduplication + speed)
+CREATE TABLE IF NOT EXISTS faq_cache (
+  id            UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  wedding_id    UUID NOT NULL REFERENCES weddings(id) ON DELETE CASCADE,
+  question_hash TEXT NOT NULL,
+  answer        TEXT NOT NULL,
+  hit_count     INT DEFAULT 1,
+  created_at    TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (wedding_id, question_hash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_faq_cache_lookup ON faq_cache(wedding_id, question_hash);
+
+-- Additional indexes for Phase 2 queries
+
+-- Upload queries: by wedding+guest, status filtering
+CREATE INDEX IF NOT EXISTS idx_uploads_gallery
+  ON uploads(wedding_id, guest_id, status, created_at DESC)
+  WHERE status = 'ready';
+
+-- AI jobs: quota counting
+CREATE INDEX IF NOT EXISTS idx_ai_jobs_quota
+  ON ai_jobs(wedding_id, guest_id, type, status)
+  WHERE type = 'portrait';
+
+-- AI jobs: polling by job ID
+CREATE INDEX IF NOT EXISTS idx_ai_jobs_status
+  ON ai_jobs(id, status);
+
+-- Feed: listing posts for a wedding
+CREATE INDEX IF NOT EXISTS idx_feed_posts_listing
+  ON feed_posts(wedding_id, is_hidden, is_pinned DESC, created_at DESC);
+
+-- Feed likes: checking if a user has liked
+CREATE INDEX IF NOT EXISTS idx_feed_likes_lookup
+  ON feed_likes(guest_id, post_id);
+
+-- Feed comments: listing by post
+CREATE INDEX IF NOT EXISTS idx_feed_comments_listing
+  ON feed_comments(post_id, created_at ASC);
+
+-- FAQ entries: by wedding for context retrieval
+CREATE INDEX IF NOT EXISTS idx_faq_entries_wedding
+  ON faq_entries(wedding_id);

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -175,6 +175,15 @@ export interface FaqEntry {
   created_at: Date;
 }
 
+export interface FaqCache {
+  id: string;
+  wedding_id: string;
+  question_hash: string;
+  answer: string;
+  hit_count: number;
+  created_at: Date;
+}
+
 export interface Notification {
   id: string;
   wedding_id: string;

--- a/tests/integration/api-ai-portrait.test.ts
+++ b/tests/integration/api-ai-portrait.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockQuery = vi.fn();
+const mockConnect = vi.fn();
+const mockRelease = vi.fn();
+const mockClientQuery = vi.fn();
+
+vi.mock('@/lib/db/client', () => ({
+  getPool: () => ({
+    query: mockQuery,
+    connect: mockConnect.mockResolvedValue({
+      query: mockClientQuery,
+      release: mockRelease,
+    }),
+  }),
+}));
+
+vi.mock('@/lib/session', () => ({
+  validateSession: vi.fn().mockResolvedValue({
+    sessionId: 's-001',
+    weddingId: 'w-001',
+    guestId: 'g-001',
+  }),
+}));
+
+vi.mock('uuid', () => ({
+  v4: () => 'job-001',
+}));
+
+import { POST } from '@/app/api/v1/w/[slug]/ai-portrait/route';
+import { GET } from '@/app/api/v1/w/[slug]/ai-portrait/[jobId]/route';
+
+function makeParams(slug = 'neil-shriya') {
+  return { params: Promise.resolve({ slug }) };
+}
+
+function makeJobParams(slug = 'neil-shriya', jobId = 'job-001') {
+  return { params: Promise.resolve({ slug, jobId }) };
+}
+
+describe('POST /api/v1/w/[slug]/ai-portrait', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockClientQuery.mockReset();
+    mockConnect.mockReset();
+    mockRelease.mockReset();
+
+    mockConnect.mockResolvedValue({
+      query: mockClientQuery,
+      release: mockRelease,
+    });
+  });
+
+  it('queues a portrait generation job', async () => {
+    // Wedding lookup
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 'w-001', package_config: { ai_portraits_per_guest: 5 }, status: 'active' }],
+    });
+
+    // Client queries inside transaction
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ count: '2' }] }) // quota check
+      .mockResolvedValueOnce({
+        rows: [{ id: '660e8400-e29b-41d4-a716-446655440001', storage_key: 'weddings/w-001/uploads/2026/03/upload-001/original.jpg', type: 'photo' }],
+      }) // source upload
+      .mockResolvedValueOnce({ rows: [] }) // insert ai_job
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/ai-portrait', {
+      method: 'POST',
+      body: JSON.stringify({
+        source_upload_id: '660e8400-e29b-41d4-a716-446655440001',
+        style_id: 'watercolor',
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: 'wedding_session=valid-token',
+      },
+    });
+
+    const response = await POST(request, makeParams());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.job_id).toBe('job-001');
+    expect(body.data.status).toBe('queued');
+    expect(body.data.style.name).toBe('Watercolor');
+    expect(body.data.quota.remaining).toBe(2); // was 3, used 1
+  });
+
+  it('rejects when portrait quota is exceeded', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 'w-001', package_config: { ai_portraits_per_guest: 5 }, status: 'active' }],
+    });
+
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ count: '5' }] }); // quota check — at limit
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/ai-portrait', {
+      method: 'POST',
+      body: JSON.stringify({
+        source_upload_id: '660e8400-e29b-41d4-a716-446655440001',
+        style_id: 'watercolor',
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: 'wedding_session=valid-token',
+      },
+    });
+
+    const response = await POST(request, makeParams());
+    expect(response.status).toBe(429);
+  });
+
+  it('rejects invalid style ID', async () => {
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/ai-portrait', {
+      method: 'POST',
+      body: JSON.stringify({
+        source_upload_id: '660e8400-e29b-41d4-a716-446655440001',
+        style_id: 'nonexistent-style',
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: 'wedding_session=valid-token',
+      },
+    });
+
+    const response = await POST(request, makeParams());
+    expect(response.status).toBe(400);
+  });
+
+  it('rejects when source upload is a video', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 'w-001', package_config: { ai_portraits_per_guest: 5 }, status: 'active' }],
+    });
+
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ count: '0' }] }) // quota
+      .mockResolvedValueOnce({
+        rows: [{ id: '660e8400-e29b-41d4-a716-446655440001', storage_key: 'test.mp4', type: 'video' }],
+      }); // source — video!
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/ai-portrait', {
+      method: 'POST',
+      body: JSON.stringify({
+        source_upload_id: '660e8400-e29b-41d4-a716-446655440001',
+        style_id: 'watercolor',
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: 'wedding_session=valid-token',
+      },
+    });
+
+    const response = await POST(request, makeParams());
+    expect(response.status).toBe(400);
+  });
+});
+
+describe('GET /api/v1/w/[slug]/ai-portrait/[jobId]', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it('returns job status for a completed portrait', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{
+        id: 'job-001',
+        status: 'completed',
+        style_id: 'watercolor',
+        output_key: 'weddings/w-001/ai/job-001/output.png',
+        error_message: null,
+        created_at: new Date().toISOString(),
+        completed_at: new Date().toISOString(),
+      }],
+    });
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/ai-portrait/job-001', {
+      headers: { Cookie: 'wedding_session=valid-token' },
+    });
+
+    const response = await GET(request, makeJobParams());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.status).toBe('completed');
+    expect(body.data.output_url).toContain('output.png');
+  });
+
+  it('returns queued status for pending job', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{
+        id: 'job-001',
+        status: 'queued',
+        style_id: 'anime',
+        output_key: null,
+        error_message: null,
+        created_at: new Date().toISOString(),
+        completed_at: null,
+      }],
+    });
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/ai-portrait/job-001', {
+      headers: { Cookie: 'wedding_session=valid-token' },
+    });
+
+    const response = await GET(request, makeJobParams());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.status).toBe('queued');
+    expect(body.data.output_url).toBeNull();
+  });
+
+  it('returns 400 for non-existent job', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/ai-portrait/no-job', {
+      headers: { Cookie: 'wedding_session=valid-token' },
+    });
+
+    const response = await GET(request, makeJobParams('neil-shriya', 'no-job'));
+    expect(response.status).toBe(400);
+  });
+});

--- a/tests/integration/api-faq.test.ts
+++ b/tests/integration/api-faq.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockQuery = vi.fn();
+vi.mock('@/lib/db/client', () => ({
+  getPool: () => ({
+    query: mockQuery,
+    connect: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/session', () => ({
+  validateSession: vi.fn().mockResolvedValue({
+    sessionId: 's-001',
+    weddingId: 'w-001',
+    guestId: 'g-001',
+  }),
+}));
+
+import { POST } from '@/app/api/v1/w/[slug]/faq/route';
+
+function makeParams(slug = 'neil-shriya') {
+  return { params: Promise.resolve({ slug }) };
+}
+
+describe('POST /api/v1/w/[slug]/faq', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it('returns an answer using mock AI in test mode', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'w-001',
+          package_config: { faq_chatbot: true },
+          display_name: "Neil & Shriya's Wedding",
+          config: {},
+        }],
+      }) // wedding lookup
+      .mockResolvedValueOnce({ rows: [] }) // cache check
+      .mockResolvedValueOnce({
+        rows: [
+          { id: 'faq-1', question: 'What is the dress code?', answer: 'Smart casual, colors preferred.' },
+          { id: 'faq-2', question: 'Where do I park?', answer: 'Free parking at the south lot.' },
+        ],
+      }) // faq entries
+      .mockResolvedValueOnce({ rows: [] }); // cache write
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/faq', {
+      method: 'POST',
+      body: JSON.stringify({ question: "What's the dress code?" }),
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: 'wedding_session=valid-token',
+      },
+    });
+
+    const response = await POST(request, makeParams());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.answer).toBeTruthy();
+    expect(body.data.answer.length).toBeGreaterThan(10);
+  });
+
+  it('returns cached answer on repeat question', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'w-001',
+          package_config: { faq_chatbot: true },
+          display_name: "Neil & Shriya's Wedding",
+          config: {},
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ answer: 'Smart casual, colors preferred.' }],
+      }) // cache hit!
+      .mockResolvedValueOnce({ rows: [] }); // increment hit
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/faq', {
+      method: 'POST',
+      body: JSON.stringify({ question: "What's the dress code?" }),
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: 'wedding_session=valid-token',
+      },
+    });
+
+    const response = await POST(request, makeParams());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.answer).toBe('Smart casual, colors preferred.');
+    expect(body.data.cached).toBe(true);
+  });
+
+  it('rejects when FAQ feature is disabled', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{
+        id: 'w-001',
+        package_config: { faq_chatbot: false },
+        display_name: "Neil & Shriya's Wedding",
+        config: {},
+      }],
+    });
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/faq', {
+      method: 'POST',
+      body: JSON.stringify({ question: "What's the dress code?" }),
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: 'wedding_session=valid-token',
+      },
+    });
+
+    const response = await POST(request, makeParams());
+    expect(response.status).toBe(403);
+  });
+
+  it('rejects empty question', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{
+        id: 'w-001',
+        package_config: { faq_chatbot: true },
+        display_name: "Neil & Shriya's Wedding",
+        config: {},
+      }],
+    });
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/faq', {
+      method: 'POST',
+      body: JSON.stringify({ question: '' }),
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: 'wedding_session=valid-token',
+      },
+    });
+
+    const response = await POST(request, makeParams());
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 401 without session', async () => {
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/faq', {
+      method: 'POST',
+      body: JSON.stringify({ question: 'Hello' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const response = await POST(request, makeParams());
+    expect(response.status).toBe(401);
+  });
+});

--- a/tests/integration/api-feed-interactions.test.ts
+++ b/tests/integration/api-feed-interactions.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockQuery = vi.fn();
+vi.mock('@/lib/db/client', () => ({
+  getPool: () => ({
+    query: mockQuery,
+    connect: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/session', () => ({
+  validateSession: vi.fn().mockResolvedValue({
+    sessionId: 's-001',
+    weddingId: 'w-001',
+    guestId: 'g-001',
+  }),
+}));
+
+import { POST as likeHandler } from '@/app/api/v1/w/[slug]/feed/[postId]/like/route';
+import { GET as getComments, POST as addComment } from '@/app/api/v1/w/[slug]/feed/[postId]/comments/route';
+
+function makeLikeParams(slug = 'neil-shriya', postId = 'p-001') {
+  return { params: Promise.resolve({ slug, postId }) };
+}
+
+describe('POST /api/v1/w/[slug]/feed/[postId]/like', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it('likes a post that is not yet liked', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 'p-001', wedding_id: 'w-001', like_count: 3, is_hidden: false }],
+      }) // post lookup
+      .mockResolvedValueOnce({ rows: [] }) // not liked yet
+      .mockResolvedValueOnce({ rows: [] }) // insert like
+      .mockResolvedValueOnce({ rows: [{ like_count: 4 }] }); // update count
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/feed/p-001/like', {
+      method: 'POST',
+      headers: { Cookie: 'wedding_session=valid-token' },
+    });
+
+    const response = await likeHandler(request, makeLikeParams());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.liked).toBe(true);
+    expect(body.data.like_count).toBe(4);
+  });
+
+  it('unlikes a post that was already liked', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 'p-001', wedding_id: 'w-001', like_count: 4, is_hidden: false }],
+      })
+      .mockResolvedValueOnce({ rows: [{ id: 'like-001' }] }) // already liked
+      .mockResolvedValueOnce({ rows: [] }) // delete like
+      .mockResolvedValueOnce({ rows: [{ like_count: 3 }] }); // update count
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/feed/p-001/like', {
+      method: 'POST',
+      headers: { Cookie: 'wedding_session=valid-token' },
+    });
+
+    const response = await likeHandler(request, makeLikeParams());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.liked).toBe(false);
+    expect(body.data.like_count).toBe(3);
+  });
+
+  it('rejects like on hidden post', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 'p-001', wedding_id: 'w-001', like_count: 0, is_hidden: true }],
+    });
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/feed/p-001/like', {
+      method: 'POST',
+      headers: { Cookie: 'wedding_session=valid-token' },
+    });
+
+    const response = await likeHandler(request, makeLikeParams());
+    expect(response.status).toBe(403);
+  });
+});
+
+describe('Comments API', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it('GET returns comments for a post', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 'p-001', wedding_id: 'w-001' }] }) // post
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'c-001',
+          content: 'Great photo!',
+          created_at: new Date().toISOString(),
+          guest_id: 'g-002',
+          first_name: 'Priya',
+          last_name: 'Patel',
+          display_name: 'Priya Patel',
+        }],
+      }); // comments
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/feed/p-001/comments', {
+      headers: { Cookie: 'wedding_session=valid-token' },
+    });
+
+    const response = await getComments(request, makeLikeParams());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.items).toHaveLength(1);
+    expect(body.data.items[0].content).toBe('Great photo!');
+    expect(body.data.items[0].guest.first_name).toBe('Priya');
+  });
+
+  it('POST creates a comment', async () => {
+    const now = new Date().toISOString();
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 'p-001', wedding_id: 'w-001', is_hidden: false }],
+      }) // post
+      .mockResolvedValueOnce({
+        rows: [{ id: 'c-new', content: 'Congratulations!', created_at: now }],
+      }) // insert
+      .mockResolvedValueOnce({ rows: [] }) // update count
+      .mockResolvedValueOnce({
+        rows: [{ id: 'g-001', first_name: 'Aditya', last_name: 'Sharma', display_name: 'Aditya Sharma' }],
+      }); // guest
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/feed/p-001/comments', {
+      method: 'POST',
+      body: JSON.stringify({ content: 'Congratulations!' }),
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: 'wedding_session=valid-token',
+      },
+    });
+
+    const response = await addComment(request, makeLikeParams());
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.data.comment.content).toBe('Congratulations!');
+    expect(body.data.comment.guest.first_name).toBe('Aditya');
+  });
+
+  it('POST rejects empty comment', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 'p-001', wedding_id: 'w-001', is_hidden: false }],
+    });
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/feed/p-001/comments', {
+      method: 'POST',
+      body: JSON.stringify({ content: '' }),
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: 'wedding_session=valid-token',
+      },
+    });
+
+    const response = await addComment(request, makeLikeParams());
+    expect(response.status).toBe(400);
+  });
+
+  it('POST rejects comment on hidden post', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 'p-001', wedding_id: 'w-001', is_hidden: true }],
+    });
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/feed/p-001/comments', {
+      method: 'POST',
+      body: JSON.stringify({ content: 'Test' }),
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: 'wedding_session=valid-token',
+      },
+    });
+
+    const response = await addComment(request, makeLikeParams());
+    expect(response.status).toBe(403);
+  });
+});

--- a/tests/integration/api-feed.test.ts
+++ b/tests/integration/api-feed.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockQuery = vi.fn();
+vi.mock('@/lib/db/client', () => ({
+  getPool: () => ({
+    query: mockQuery,
+    connect: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/session', () => ({
+  validateSession: vi.fn().mockResolvedValue({
+    sessionId: 's-001',
+    weddingId: 'w-001',
+    guestId: 'g-001',
+  }),
+}));
+
+import { GET, POST } from '@/app/api/v1/w/[slug]/feed/route';
+
+function makeParams(slug = 'neil-shriya') {
+  return { params: Promise.resolve({ slug }) };
+}
+
+describe('GET /api/v1/w/[slug]/feed', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it('returns paginated feed posts', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 'w-001' }] }) // wedding
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'p-001',
+            type: 'text',
+            content: 'What a beautiful ceremony!',
+            photo_key: null,
+            like_count: 3,
+            comment_count: 1,
+            is_pinned: false,
+            created_at: new Date().toISOString(),
+            guest_id: 'g-002',
+            first_name: 'Priya',
+            last_name: 'Patel',
+            display_name: 'Priya Patel',
+          },
+        ],
+      }) // posts
+      .mockResolvedValueOnce({ rows: [] }); // likes
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/feed', {
+      headers: { Cookie: 'wedding_session=valid-token' },
+    });
+
+    const response = await GET(request, makeParams());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.items).toHaveLength(1);
+    expect(body.data.items[0].content).toBe('What a beautiful ceremony!');
+    expect(body.data.items[0].guest.first_name).toBe('Priya');
+    expect(body.data.items[0].is_liked).toBe(false);
+    expect(body.data.has_more).toBe(false);
+  });
+
+  it('returns empty list for wedding with no posts', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 'w-001' }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/feed', {
+      headers: { Cookie: 'wedding_session=valid-token' },
+    });
+
+    const response = await GET(request, makeParams());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.items).toHaveLength(0);
+  });
+
+  it('returns 401 without session', async () => {
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/feed');
+
+    const response = await GET(request, makeParams());
+    expect(response.status).toBe(401);
+  });
+});
+
+describe('POST /api/v1/w/[slug]/feed', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it('creates a text post', async () => {
+    const now = new Date().toISOString();
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 'w-001', package_config: { social_feed: true } }] }) // wedding
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'p-new',
+          type: 'text',
+          content: 'Having an amazing time!',
+          photo_key: null,
+          like_count: 0,
+          comment_count: 0,
+          is_pinned: false,
+          created_at: now,
+        }],
+      }) // insert
+      .mockResolvedValueOnce({
+        rows: [{ id: 'g-001', first_name: 'Aditya', last_name: 'Sharma', display_name: 'Aditya Sharma' }],
+      }); // guest
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/feed', {
+      method: 'POST',
+      body: JSON.stringify({ type: 'text', content: 'Having an amazing time!' }),
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: 'wedding_session=valid-token',
+      },
+    });
+
+    const response = await POST(request, makeParams());
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.data.post.content).toBe('Having an amazing time!');
+    expect(body.data.post.type).toBe('text');
+    expect(body.data.post.guest.first_name).toBe('Aditya');
+  });
+
+  it('creates a memory post', async () => {
+    const now = new Date().toISOString();
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 'w-001', package_config: { social_feed: true } }] })
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'p-new',
+          type: 'memory',
+          content: 'I remember when they first met...',
+          photo_key: null,
+          like_count: 0,
+          comment_count: 0,
+          is_pinned: false,
+          created_at: now,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ id: 'g-001', first_name: 'Aditya', last_name: 'Sharma', display_name: 'Aditya Sharma' }],
+      });
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/feed', {
+      method: 'POST',
+      body: JSON.stringify({ type: 'memory', content: 'I remember when they first met...' }),
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: 'wedding_session=valid-token',
+      },
+    });
+
+    const response = await POST(request, makeParams());
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.data.post.type).toBe('memory');
+  });
+
+  it('rejects post without content or photo', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 'w-001', package_config: { social_feed: true } }] });
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/feed', {
+      method: 'POST',
+      body: JSON.stringify({ type: 'text' }),
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: 'wedding_session=valid-token',
+      },
+    });
+
+    const response = await POST(request, makeParams());
+    expect(response.status).toBe(400);
+  });
+
+  it('rejects post when social feed feature is disabled', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 'w-001', package_config: { social_feed: false } }] });
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/feed', {
+      method: 'POST',
+      body: JSON.stringify({ type: 'text', content: 'Hello!' }),
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: 'wedding_session=valid-token',
+      },
+    });
+
+    const response = await POST(request, makeParams());
+    expect(response.status).toBe(403);
+  });
+});

--- a/tests/integration/api-media.test.ts
+++ b/tests/integration/api-media.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockQuery = vi.fn();
+vi.mock('@/lib/db/client', () => ({
+  getPool: () => ({
+    query: mockQuery,
+    connect: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/session', () => ({
+  validateSession: vi.fn().mockResolvedValue({
+    sessionId: 's-001',
+    weddingId: 'w-001',
+    guestId: 'g-001',
+  }),
+}));
+
+import { GET } from '@/app/api/v1/w/[slug]/media/[guestId]/route';
+
+function makeParams(slug = 'neil-shriya', guestId = 'g-001') {
+  return { params: Promise.resolve({ slug, guestId }) };
+}
+
+describe('GET /api/v1/w/[slug]/media/[guestId]', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it('returns media items for a guest', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 'w-001' }] }) // wedding
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'u-001',
+            type: 'photo',
+            storage_key: 'weddings/w-001/uploads/2026/03/u-001/original.jpg',
+            thumbnail_key: 'weddings/w-001/uploads/2026/03/u-001/thumbnail.jpg',
+            filter_applied: 'golden-hour',
+            duration_ms: null,
+            created_at: '2026-03-03T12:00:00.000Z',
+            event_name: 'Ceremony',
+          },
+          {
+            id: 'u-002',
+            type: 'video',
+            storage_key: 'weddings/w-001/uploads/2026/03/u-002/original.mp4',
+            thumbnail_key: 'weddings/w-001/uploads/2026/03/u-002/thumbnail.jpg',
+            filter_applied: null,
+            duration_ms: 45000,
+            created_at: '2026-03-03T11:00:00.000Z',
+            event_name: null,
+          },
+        ],
+      }) // uploads
+      .mockResolvedValueOnce({ rows: [] }); // portraits
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/media/g-001?limit=20', {
+      headers: { Cookie: 'wedding_session=valid-token' },
+    });
+
+    const response = await GET(request, makeParams());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.items).toHaveLength(2);
+    expect(body.data.items[0].type).toBe('photo');
+    expect(body.data.items[0].url).toContain('original.jpg');
+    expect(body.data.items[0].filter_applied).toBe('golden-hour');
+    expect(body.data.items[1].type).toBe('video');
+    expect(body.data.items[1].duration_ms).toBe(45000);
+    expect(body.data.has_more).toBe(false);
+  });
+
+  it('includes AI portraits in results', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 'w-001' }] }) // wedding
+      .mockResolvedValueOnce({ rows: [] }) // uploads (empty)
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'ai-001',
+          type: 'portrait',
+          storage_key: 'weddings/w-001/ai/ai-001/output.png',
+          thumbnail_key: 'weddings/w-001/ai/ai-001/output.png',
+          filter_applied: 'watercolor',
+          duration_ms: null,
+          created_at: new Date().toISOString(),
+          event_name: null,
+        }],
+      }); // portraits
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/media/g-001?limit=20', {
+      headers: { Cookie: 'wedding_session=valid-token' },
+    });
+
+    const response = await GET(request, makeParams());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.items).toHaveLength(1);
+    expect(body.data.items[0].type).toBe('portrait');
+  });
+
+  it('filters by type when specified', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 'w-001' }] })
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'u-001',
+          type: 'photo',
+          storage_key: 'test.jpg',
+          thumbnail_key: 'test-thumb.jpg',
+          filter_applied: null,
+          duration_ms: null,
+          created_at: new Date().toISOString(),
+          event_name: null,
+        }],
+      }); // only photo query (no portrait query because type=photo)
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/media/g-001?type=photo&limit=20', {
+      headers: { Cookie: 'wedding_session=valid-token' },
+    });
+
+    const response = await GET(request, makeParams());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.items).toHaveLength(1);
+    expect(body.data.items[0].type).toBe('photo');
+  });
+
+  it('returns empty for guest with no media', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 'w-001' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/media/g-001?limit=20', {
+      headers: { Cookie: 'wedding_session=valid-token' },
+    });
+
+    const response = await GET(request, makeParams());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.items).toHaveLength(0);
+    expect(body.data.has_more).toBe(false);
+  });
+
+  it('returns 401 without session', async () => {
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/media/g-001');
+
+    const response = await GET(request, makeParams());
+    expect(response.status).toBe(401);
+  });
+});

--- a/tests/integration/api-upload.test.ts
+++ b/tests/integration/api-upload.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// Mock database
+const mockQuery = vi.fn();
+const mockConnect = vi.fn();
+const mockRelease = vi.fn();
+const mockClientQuery = vi.fn();
+
+vi.mock('@/lib/db/client', () => ({
+  getPool: () => ({
+    query: mockQuery,
+    connect: mockConnect,
+  }),
+}));
+
+// Mock session validation
+vi.mock('@/lib/session', () => ({
+  validateSession: vi.fn().mockResolvedValue({
+    sessionId: 's-001',
+    weddingId: 'w-001',
+    guestId: 'g-001',
+  }),
+}));
+
+// Mock uuid
+vi.mock('uuid', () => ({
+  v4: () => 'upload-001',
+}));
+
+import { POST as presignHandler } from '@/app/api/v1/w/[slug]/upload/presign/route';
+import { POST as completeHandler } from '@/app/api/v1/w/[slug]/upload/complete/route';
+
+function makeRequest(body: unknown, slug = 'neil-shriya') {
+  return new NextRequest(`http://localhost:3000/api/v1/w/${slug}/upload/presign`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: {
+      'Content-Type': 'application/json',
+      Cookie: 'wedding_session=valid-token',
+    },
+  });
+}
+
+function makeParams(slug = 'neil-shriya') {
+  return { params: Promise.resolve({ slug }) };
+}
+
+describe('POST /api/v1/w/[slug]/upload/presign', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it('returns presigned URL for a valid photo upload', async () => {
+    // Mock wedding lookup
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 'w-001', status: 'active' }] }) // wedding
+      .mockResolvedValueOnce({ rows: [] }) // insert upload
+      .mockResolvedValueOnce({ rows: [] }); // update storage key
+
+    const response = await presignHandler(
+      makeRequest({
+        type: 'photo',
+        mime_type: 'image/jpeg',
+        size_bytes: 1024000,
+      }),
+      makeParams()
+    );
+
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.upload_id).toBe('upload-001');
+    expect(body.data.presigned_url).toBeDefined();
+    expect(body.data.storage_key).toContain('weddings/w-001');
+    expect(body.data.expires_at).toBeDefined();
+    expect(body.data.multipart).toBe(false);
+  });
+
+  it('returns 401 without session cookie', async () => {
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/upload/presign', {
+      method: 'POST',
+      body: JSON.stringify({ type: 'photo', mime_type: 'image/jpeg', size_bytes: 1024 }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const response = await presignHandler(request, makeParams());
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 400 for invalid mime type', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 'w-001', status: 'active' }] });
+
+    const response = await presignHandler(
+      makeRequest({
+        type: 'photo',
+        mime_type: 'application/pdf',
+        size_bytes: 1024,
+      }),
+      makeParams()
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 400 for file over size limit', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 'w-001', status: 'active' }] });
+
+    const response = await presignHandler(
+      makeRequest({
+        type: 'video',
+        mime_type: 'video/mp4',
+        size_bytes: 600_000_000,
+      }),
+      makeParams()
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it('indicates multipart for large video uploads', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 'w-001', status: 'active' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const response = await presignHandler(
+      makeRequest({
+        type: 'video',
+        mime_type: 'video/mp4',
+        size_bytes: 150_000_000,
+      }),
+      makeParams()
+    );
+
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body.data.multipart).toBe(true);
+  });
+
+  it('returns 404 for non-existent wedding', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] }); // no wedding
+
+    const response = await presignHandler(
+      makeRequest({
+        type: 'photo',
+        mime_type: 'image/jpeg',
+        size_bytes: 1024,
+      }),
+      makeParams('no-wedding')
+    );
+
+    expect(response.status).toBe(404);
+  });
+});
+
+const UPLOAD_UUID = '660e8400-e29b-41d4-a716-446655440001';
+
+describe('POST /api/v1/w/[slug]/upload/complete', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it('marks upload as ready and returns media info', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: UPLOAD_UUID, wedding_id: 'w-001', guest_id: 'g-001', status: 'uploading' }],
+      }) // find upload
+      .mockResolvedValueOnce({
+        rows: [{
+          id: UPLOAD_UUID,
+          type: 'photo',
+          storage_key: `weddings/w-001/uploads/2026/03/${UPLOAD_UUID}/original.jpg`,
+          thumbnail_key: `weddings/w-001/uploads/2026/03/${UPLOAD_UUID}/thumbnail.jpg`,
+          size_bytes: 1024000,
+          status: 'ready',
+          created_at: new Date().toISOString(),
+        }],
+      }) // update upload
+      .mockResolvedValueOnce({ rows: [] }); // update wedding storage
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/upload/complete', {
+      method: 'POST',
+      body: JSON.stringify({
+        upload_id: UPLOAD_UUID,
+        storage_key: `weddings/w-001/uploads/2026/03/${UPLOAD_UUID}/original.jpg`,
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: 'wedding_session=valid-token',
+      },
+    });
+
+    const response = await completeHandler(request, makeParams());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.upload.id).toBe(UPLOAD_UUID);
+    expect(body.data.upload.status).toBe('ready');
+    expect(body.data.upload.url).toContain('original.jpg');
+  });
+
+  it('rejects upload that does not belong to guest', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: UPLOAD_UUID, wedding_id: 'w-other', guest_id: 'g-other', status: 'uploading' }],
+    });
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/upload/complete', {
+      method: 'POST',
+      body: JSON.stringify({
+        upload_id: UPLOAD_UUID,
+        storage_key: 'weddings/w-001/uploads/test/original.jpg',
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: 'wedding_session=valid-token',
+      },
+    });
+
+    const response = await completeHandler(request, makeParams());
+    expect(response.status).toBe(401);
+  });
+
+  it('rejects already-completed upload', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: UPLOAD_UUID, wedding_id: 'w-001', guest_id: 'g-001', status: 'ready' }],
+    });
+
+    const request = new NextRequest('http://localhost:3000/api/v1/w/neil-shriya/upload/complete', {
+      method: 'POST',
+      body: JSON.stringify({
+        upload_id: UPLOAD_UUID,
+        storage_key: 'weddings/w-001/uploads/test/original.jpg',
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: 'wedding_session=valid-token',
+      },
+    });
+
+    const response = await completeHandler(request, makeParams());
+    expect(response.status).toBe(400);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -29,32 +29,36 @@ vi.mock('@/lib/storage/r2', () => ({
 }));
 
 // Mock OpenAI
-vi.mock('@/lib/ai/openai', () => ({
-  openaiClient: {
-    images: {
-      edit: vi.fn().mockResolvedValue({
-        data: [{ url: 'https://mock-openai.example.com/portrait.png' }],
-      }),
-    },
-    chat: {
-      completions: {
-        create: vi.fn().mockResolvedValue({
-          choices: [{ message: { content: 'Mock AI response' } }],
+vi.mock('@/lib/ai/openai', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/ai/openai')>();
+  return {
+    ...actual,
+    getOpenAIClient: vi.fn().mockReturnValue({
+      images: {
+        edit: vi.fn().mockResolvedValue({
+          data: [{ url: 'https://mock-openai.example.com/portrait.png' }],
         }),
       },
-    },
-    embeddings: {
-      create: vi.fn().mockResolvedValue({
-        data: [{ embedding: new Array(1536).fill(0.01) }],
-      }),
-    },
-    audio: {
-      transcriptions: {
-        create: vi.fn().mockResolvedValue({ text: 'Mock transcript of a wedding toast.' }),
+      chat: {
+        completions: {
+          create: vi.fn().mockResolvedValue({
+            choices: [{ message: { content: 'Mock AI response' } }],
+          }),
+        },
       },
-    },
-  },
-}));
+      embeddings: {
+        create: vi.fn().mockResolvedValue({
+          data: [{ embedding: new Array(1536).fill(0.01) }],
+        }),
+      },
+      audio: {
+        transcriptions: {
+          create: vi.fn().mockResolvedValue({ text: 'Mock transcript of a wedding toast.' }),
+        },
+      },
+    }),
+  };
+});
 
 // Mock email
 vi.mock('@/lib/email/ses', () => ({

--- a/tests/unit/ai/openai-client.test.ts
+++ b/tests/unit/ai/openai-client.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { AI_PORTRAIT_STYLES, IMAGE_MODEL, CHAT_MODEL, CHAT_MODEL_MINI, EMBEDDING_MODEL } from '@/lib/ai/openai';
+
+describe('OpenAI Client Configuration', () => {
+  it('uses non-deprecated models', () => {
+    // gpt-image-1 is the current image generation model
+    expect(IMAGE_MODEL).toBe('gpt-image-1');
+    // gpt-4.1 is the current chat model
+    expect(CHAT_MODEL).toBe('gpt-4.1');
+    // gpt-4.1-mini is the current small chat model
+    expect(CHAT_MODEL_MINI).toBe('gpt-4.1-mini');
+    // text-embedding-3-small is current embedding model
+    expect(EMBEDDING_MODEL).toBe('text-embedding-3-small');
+
+    // Ensure we're NOT using deprecated models
+    expect(IMAGE_MODEL).not.toBe('dall-e-2');
+    expect(IMAGE_MODEL).not.toBe('dall-e-3');
+    expect(CHAT_MODEL).not.toBe('gpt-4o-mini');
+    expect(CHAT_MODEL).not.toBe('gpt-3.5-turbo');
+    expect(CHAT_MODEL_MINI).not.toBe('gpt-4o-mini');
+  });
+
+  it('defines all portrait styles with required fields', () => {
+    const styles = Object.entries(AI_PORTRAIT_STYLES);
+    expect(styles.length).toBeGreaterThanOrEqual(8);
+
+    for (const [id, style] of styles) {
+      expect(id).toBeTruthy();
+      expect(style.name).toBeTruthy();
+      expect(style.prompt).toBeTruthy();
+      expect(style.prompt.length).toBeGreaterThan(20);
+      expect(style.estimatedSeconds).toBeGreaterThan(0);
+    }
+  });
+
+  it('has unique style IDs', () => {
+    const ids = Object.keys(AI_PORTRAIT_STYLES);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(ids.length);
+  });
+
+  it('includes expected styles', () => {
+    expect(AI_PORTRAIT_STYLES['watercolor']).toBeDefined();
+    expect(AI_PORTRAIT_STYLES['castle-wedding']).toBeDefined();
+    expect(AI_PORTRAIT_STYLES['pop-art']).toBeDefined();
+    expect(AI_PORTRAIT_STYLES['anime']).toBeDefined();
+  });
+});


### PR DESCRIPTION
…its, feed, FAQ

Phase 2 adds all capture features with full API routes, UI pages, and tests:

**Upload Flow (presign + complete)**
- POST /api/v1/w/[slug]/upload/presign — generates R2 presigned URLs
- POST /api/v1/w/[slug]/upload/complete — marks uploads ready, updates storage

**Media Gallery**
- GET /api/v1/w/[slug]/media/[guestId] — paginated media with type filtering
- Merges photos, videos, and AI portraits in a unified feed
- Gallery page with grid view, filter tabs, and load-more pagination

**AI Portraits (gpt-image-1, non-deprecated)**
- POST /api/v1/w/[slug]/ai-portrait — queue portrait generation with quota check
- GET /api/v1/w/[slug]/ai-portrait/[jobId] — poll job status
- 10 styles: watercolor, castle-wedding, mughal, bollywood, renaissance, etc.
- Per-guest quota enforcement from package config

**Social Feed**
- GET/POST /api/v1/w/[slug]/feed — list + create posts (text, photo, memory)
- POST /feed/[postId]/like — toggle like with count tracking
- GET/POST /feed/[postId]/comments — list + add comments
- Feature-gated by package_config.social_feed

**FAQ Chatbot (gpt-4.1-mini, non-deprecated)**
- POST /api/v1/w/[slug]/faq — ask questions with AI-powered answers
- SHA-256 question hashing with DB cache for deduplication
- Feature-gated by package_config.faq_chatbot

**Supporting changes**
- lib/ai/openai.ts — OpenAI client with current models (gpt-image-1, gpt-4.1, gpt-4.1-mini)
- lib/db/migrations/002_phase2_capture.sql — FAQ cache table + performance indexes
- Updated test setup mock to use importOriginal for AI module
- 112 tests passing across 19 test files, TypeScript compiles clean

https://claude.ai/code/session_01RzXnQstS7hdW1Cp1nBAf8P