### PR TITLE
fix: Rename middleware.ts to proxy.ts for Next.js 16 + add vercel.json

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   // Handle /w/[slug] routes — resolve wedding slug

--- a/tests/unit/middleware.test.ts
+++ b/tests/unit/middleware.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { NextRequest } from 'next/server';
-import { middleware } from '@/middleware';
+import { proxy as middleware } from '@/proxy';
 
 function makeRequest(path: string) {
   return new NextRequest(`http://localhost:3000${path}`);

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "framework": "nextjs",
+  "buildCommand": "next build",
+  "outputDirectory": ".next"
+}


### PR DESCRIPTION
Next.js 16 deprecated middleware.ts in favor of proxy.ts. On Vercel, this mismatch causes the routing layer to fail, resulting in a 404 even when the build succeeds. Renamed the file and export function to match the new convention. Added vercel.json to explicitly set the Next.js framework.

https://claude.ai/code/session_01RzXnQstS7hdW1Cp1nBAf8P