### PR TITLE
Redesign travel page to match elevated design language

### DIFF
--- a/app/w/[slug]/travel/page.tsx
+++ b/app/w/[slug]/travel/page.tsx
@@ -103,7 +103,7 @@ export default function TravelPage() {
               color: 'var(--text-primary)',
             }}
           >
-            Guest Travel
+            Travel
           </h2>
           <div className="flex items-center justify-center gap-3">
             <span className="h-px w-8" style={{ background: 'var(--border-light)' }} />
@@ -115,7 +115,7 @@ export default function TravelPage() {
                 color: 'var(--color-terracotta)',
               }}
             >
-              Find nearby matches
+              Connect with fellow guests
             </p>
             <span className="h-px w-8" style={{ background: 'var(--border-light)' }} />
           </div>
@@ -123,27 +123,39 @@ export default function TravelPage() {
 
         {/* Tab bar */}
         <div
-          className="flex rounded-xl p-1 mb-5"
-          style={{ background: 'var(--bg-muted, #f5f3f0)' }}
+          className="flex rounded-2xl p-1.5 mb-6"
+          style={{
+            background: 'var(--bg-pure-white)',
+            border: '1px solid var(--border-light)',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.03)',
+          }}
         >
           {([
-            { id: 'travel' as Tab, label: 'Travel' },
-            { id: 'arrivals' as Tab, label: 'Arrivals' },
-            { id: 'my-plan' as Tab, label: 'My Plan' },
-          ]).map((tab) => (
-            <button
-              key={tab.id}
-              onClick={() => setActiveTab(tab.id)}
-              className="flex-1 py-2 text-sm font-medium rounded-lg transition-colors"
-              style={{
-                background: activeTab === tab.id ? 'white' : 'transparent',
-                color: activeTab === tab.id ? 'var(--text-primary)' : 'var(--text-tertiary)',
-                boxShadow: activeTab === tab.id ? '0 1px 3px rgba(0,0,0,0.08)' : 'none',
-              }}
-            >
-              {tab.label}
-            </button>
-          ))}
+            { id: 'travel' as Tab, label: 'Explore', icon: 'M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0118 0z' },
+            { id: 'arrivals' as Tab, label: 'Arrivals', icon: 'M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 00-2.91-.09zM12 15l-3-3a22 22 0 012-3.95A12.88 12.88 0 0122 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 01-4 2z' },
+            { id: 'my-plan' as Tab, label: 'My Plan', icon: 'M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7' },
+          ]).map((tab) => {
+            const isActive = activeTab === tab.id;
+            return (
+              <button
+                key={tab.id}
+                onClick={() => setActiveTab(tab.id)}
+                className="flex-1 flex items-center justify-center gap-1.5 py-2.5 text-sm font-medium rounded-xl transition-all duration-200"
+                style={{
+                  background: isActive
+                    ? 'linear-gradient(135deg, var(--color-gold-dark), var(--color-gold))'
+                    : 'transparent',
+                  color: isActive ? '#FDFBF7' : 'var(--text-tertiary)',
+                  boxShadow: isActive ? '0 2px 8px rgba(198,163,85,0.25)' : 'none',
+                }}
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d={tab.icon} />
+                </svg>
+                {tab.label}
+              </button>
+            );
+          })}
         </div>
 
         {/* Tab content */}

--- a/components/travel/ArrivalsView.tsx
+++ b/components/travel/ArrivalsView.tsx
@@ -57,8 +57,8 @@ export default function ArrivalsView({ slug }: { slug: string }) {
     return (
       <div className="space-y-3">
         <div className="skeleton h-6 w-40" />
-        <div className="skeleton h-16 w-full rounded-xl" />
-        <div className="skeleton h-16 w-full rounded-xl" />
+        <div className="skeleton h-16 w-full rounded-2xl" />
+        <div className="skeleton h-16 w-full rounded-2xl" />
       </div>
     );
   }
@@ -79,115 +79,158 @@ export default function ArrivalsView({ slug }: { slug: string }) {
 
   if (arrivals.length === 0) {
     return (
-      <div className="card p-8 text-center">
-        <p className="text-3xl mb-3">&#9992;&#65039;</p>
-        <p style={{ color: 'var(--text-secondary)' }}>
+      <div
+        className="rounded-2xl p-8 text-center"
+        style={{
+          background: 'var(--bg-pure-white)',
+          border: '1px solid var(--border-light)',
+        }}
+      >
+        <div
+          className="w-12 h-12 rounded-full flex items-center justify-center mx-auto mb-3"
+          style={{ background: 'rgba(196,112,75,0.06)' }}
+        >
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="var(--color-terracotta)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 00-2.91-.09z" />
+            <path d="M12 15l-3-3a22 22 0 012-3.95A12.88 12.88 0 0122 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 01-4 2z" />
+          </svg>
+        </div>
+        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
           No arrival info shared yet
         </p>
       </div>
     );
   }
 
-  return (
-    <div className="space-y-6">
-      {/* Arrivals */}
-      <div>
-        <h3
-          className="text-lg font-medium mb-3"
-          style={{ fontFamily: 'var(--font-display)', color: 'var(--text-primary)' }}
-        >
-          Arrivals
-        </h3>
-        {groupByDate(arrivingGuests, 'arrive_date').map(([date, guests]) => (
-          <div key={date} className="mb-4">
-            <p className="text-xs font-medium mb-2" style={{ color: 'var(--text-tertiary)' }}>
-              {date !== 'Unknown' ? formatDateLabel(date) : 'Date TBD'}
-            </p>
-            <div className="space-y-2">
-              {guests.map((guest) => (
-                <div
-                  key={guest.guest_id}
-                  className="card p-3 flex items-center gap-3"
-                >
-                  <div
-                    className="w-8 h-8 rounded-full flex items-center justify-center text-xs font-medium flex-shrink-0"
-                    style={{ background: 'var(--color-terracotta)', color: 'white' }}
-                  >
-                    {guest.display_name.charAt(0)}
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
-                      {guest.display_name}
-                    </p>
-                    <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
-                      {guest.arrive_time ? formatTime(guest.arrive_time) : ''}{' '}
-                      {guest.transport_mode && transportIcon[guest.transport_mode]}{' '}
-                      {guest.transport_details || ''}
-                      {guest.origin_city ? ` from ${guest.origin_city}` : ''}
-                    </p>
-                  </div>
-                  {guest.share_transport && (
-                    <span
-                      className="text-xs px-2 py-0.5 rounded-full flex-shrink-0"
-                      style={{ background: 'var(--bg-muted, #f5f3f0)', color: 'var(--text-tertiary)' }}
-                    >
-                      Open to sharing
-                    </span>
-                  )}
-                </div>
-              ))}
-            </div>
+  function renderSection(
+    title: string,
+    icon: string,
+    iconColor: string,
+    bgTint: string,
+    guests: ArrivalInfo[],
+    dateField: 'arrive_date' | 'depart_date',
+    emptyText: string,
+    avatarBg: string,
+  ) {
+    return (
+      <section>
+        <div className="flex items-center gap-3 mb-4">
+          <div
+            className="w-8 h-8 rounded-lg flex items-center justify-center"
+            style={{ background: bgTint }}
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke={iconColor} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d={icon} />
+            </svg>
           </div>
-        ))}
-        {arrivingGuests.length === 0 && (
-          <p className="text-sm" style={{ color: 'var(--text-tertiary)' }}>No arrivals shared yet</p>
-        )}
-      </div>
+          <h3
+            className="text-xl"
+            style={{ fontFamily: 'var(--font-display)', color: 'var(--text-primary)' }}
+          >
+            {title}
+          </h3>
+          {guests.length > 0 && (
+            <span
+              className="text-xs px-2.5 py-1 rounded-full ml-auto font-medium"
+              style={{ background: bgTint, color: iconColor }}
+            >
+              {guests.length}
+            </span>
+          )}
+        </div>
 
-      {/* Departures */}
-      <div>
-        <h3
-          className="text-lg font-medium mb-3"
-          style={{ fontFamily: 'var(--font-display)', color: 'var(--text-primary)' }}
-        >
-          Departures
-        </h3>
-        {groupByDate(departingGuests, 'depart_date').map(([date, guests]) => (
-          <div key={date} className="mb-4">
-            <p className="text-xs font-medium mb-2" style={{ color: 'var(--text-tertiary)' }}>
-              {date !== 'Unknown' ? formatDateLabel(date) : 'Date TBD'}
-            </p>
-            <div className="space-y-2">
-              {guests.map((guest) => (
-                <div
-                  key={guest.guest_id}
-                  className="card p-3 flex items-center gap-3"
+        {guests.length === 0 ? (
+          <p className="text-sm pl-11" style={{ color: 'var(--text-tertiary)', fontStyle: 'italic' }}>
+            {emptyText}
+          </p>
+        ) : (
+          <div className="space-y-4">
+            {groupByDate(guests, dateField).map(([date, dateGuests]) => (
+              <div key={date}>
+                <p
+                  className="text-xs font-semibold uppercase tracking-wider mb-2 pl-1"
+                  style={{ color: 'var(--text-tertiary)' }}
                 >
-                  <div
-                    className="w-8 h-8 rounded-full flex items-center justify-center text-xs font-medium flex-shrink-0"
-                    style={{ background: 'var(--color-olive, #6b7280)', color: 'white' }}
-                  >
-                    {guest.display_name.charAt(0)}
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
-                      {guest.display_name}
-                    </p>
-                    <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
-                      {guest.depart_time ? formatTime(guest.depart_time) : ''}{' '}
-                      {guest.transport_mode && transportIcon[guest.transport_mode]}{' '}
-                      {guest.transport_details || ''}
-                    </p>
-                  </div>
+                  {date !== 'Unknown' ? formatDateLabel(date) : 'Date TBD'}
+                </p>
+                <div className="space-y-2">
+                  {dateGuests.map((guest) => (
+                    <div
+                      key={guest.guest_id}
+                      className="flex items-center gap-3 p-3.5 rounded-2xl"
+                      style={{
+                        background: 'var(--bg-pure-white)',
+                        border: '1px solid var(--border-light)',
+                        boxShadow: '0 1px 4px rgba(0,0,0,0.02)',
+                      }}
+                    >
+                      <div
+                        className="w-10 h-10 rounded-full flex items-center justify-center text-sm font-semibold flex-shrink-0"
+                        style={{
+                          background: avatarBg,
+                          color: '#FDFBF7',
+                          boxShadow: '0 2px 6px rgba(0,0,0,0.1)',
+                        }}
+                      >
+                        {guest.display_name.charAt(0)}
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
+                          {guest.display_name}
+                        </p>
+                        <p className="text-xs mt-0.5" style={{ color: 'var(--text-secondary)' }}>
+                          {dateField === 'arrive_date' && guest.arrive_time ? formatTime(guest.arrive_time) : ''}
+                          {dateField === 'depart_date' && guest.depart_time ? formatTime(guest.depart_time) : ''}
+                          {guest.transport_mode && ` ${transportIcon[guest.transport_mode]}`}
+                          {guest.transport_details && ` ${guest.transport_details}`}
+                          {guest.origin_city ? ` from ${guest.origin_city}` : ''}
+                        </p>
+                      </div>
+                      {guest.share_transport && (
+                        <span
+                          className="text-[11px] font-medium px-2.5 py-1 rounded-full flex-shrink-0"
+                          style={{
+                            background: 'rgba(198,163,85,0.1)',
+                            color: 'var(--color-gold-dark)',
+                          }}
+                        >
+                          Sharing
+                        </span>
+                      )}
+                    </div>
+                  ))}
                 </div>
-              ))}
-            </div>
+              </div>
+            ))}
           </div>
-        ))}
-        {departingGuests.length === 0 && (
-          <p className="text-sm" style={{ color: 'var(--text-tertiary)' }}>No departures shared yet</p>
         )}
-      </div>
+      </section>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      {renderSection(
+        'Arrivals',
+        'M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 00-2.91-.09zM12 15l-3-3a22 22 0 012-3.95A12.88 12.88 0 0122 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 01-4 2z',
+        'var(--color-terracotta)',
+        'rgba(196,112,75,0.08)',
+        arrivingGuests,
+        'arrive_date',
+        'No arrivals shared yet',
+        'linear-gradient(145deg, var(--color-terracotta), #d4896a)',
+      )}
+
+      {renderSection(
+        'Departures',
+        'M22 12h-4l-3 9L9 3l-3 9H2',
+        'var(--color-olive)',
+        'rgba(122,139,92,0.08)',
+        departingGuests,
+        'depart_date',
+        'No departures shared yet',
+        'linear-gradient(145deg, var(--color-olive), #8fa069)',
+      )}
     </div>
   );
 }

--- a/components/travel/TravelListView.tsx
+++ b/components/travel/TravelListView.tsx
@@ -159,57 +159,152 @@ export default function TravelListView({
   }
 
   return (
-    <div className="space-y-5">
+    <div className="space-y-6">
+      {/* Prompt to add plan — hero CTA card */}
+      {hasPlan === false && (
+        <button
+          onClick={onAddPlan}
+          className="w-full group overflow-hidden rounded-2xl flex flex-col relative transition-all duration-300 hover:shadow-lg text-left"
+          style={{
+            background: 'linear-gradient(145deg, rgba(198,163,85,0.08) 0%, rgba(196,112,75,0.06) 100%)',
+            border: '1px solid rgba(198,163,85,0.15)',
+          }}
+        >
+          <div className="p-6 flex items-start gap-4">
+            <div
+              className="w-12 h-12 rounded-2xl flex items-center justify-center flex-shrink-0"
+              style={{
+                background: 'linear-gradient(135deg, var(--color-gold-dark), var(--color-gold))',
+                boxShadow: '0 4px 12px rgba(198,163,85,0.3)',
+              }}
+            >
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#FDFBF7" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0118 0z" />
+                <circle cx="12" cy="10" r="3" />
+              </svg>
+            </div>
+            <div className="flex-1 min-w-0">
+              <h3
+                className="text-lg mb-1"
+                style={{ fontFamily: 'var(--font-display)', color: 'var(--text-primary)' }}
+              >
+                Share Your Journey
+              </h3>
+              <p className="text-sm leading-relaxed" style={{ color: 'var(--text-secondary)' }}>
+                Add your travel plans to discover guests nearby and find ride shares
+              </p>
+              <div
+                className="mt-3 inline-flex items-center gap-1.5 text-xs font-semibold tracking-wider uppercase"
+                style={{ color: 'var(--color-gold-dark)' }}
+              >
+                Add My Plans
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                  <path d="M5 12h14M12 5l7 7-7 7" />
+                </svg>
+              </div>
+            </div>
+          </div>
+        </button>
+      )}
+
       {/* Your Matches section */}
       {hasPlan && (
         <section>
-          <h2
-            className="text-base font-medium mb-3"
-            style={{ fontFamily: 'var(--font-display)', color: 'var(--text-primary)' }}
-          >
-            Your Matches
-          </h2>
+          <div className="flex items-center gap-3 mb-4">
+            <div
+              className="w-8 h-8 rounded-lg flex items-center justify-center"
+              style={{ background: 'rgba(198,163,85,0.1)' }}
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--color-gold-dark)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2" />
+                <circle cx="9" cy="7" r="4" />
+                <path d="M23 21v-2a4 4 0 00-3-3.87" />
+                <path d="M16 3.13a4 4 0 010 7.75" />
+              </svg>
+            </div>
+            <h2
+              className="text-xl"
+              style={{ fontFamily: 'var(--font-display)', color: 'var(--text-primary)' }}
+            >
+              Your Matches
+            </h2>
+          </div>
 
           {overlaps.length === 0 ? (
             <div
-              className="card p-5 text-center"
-              style={{ background: 'var(--bg-muted, #f9f8f6)' }}
+              className="rounded-2xl p-6 text-center"
+              style={{
+                background: 'var(--bg-pure-white)',
+                border: '1px solid var(--border-light)',
+              }}
             >
+              <div
+                className="w-10 h-10 rounded-full flex items-center justify-center mx-auto mb-3"
+                style={{ background: 'rgba(198,163,85,0.08)' }}
+              >
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--color-gold)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                  <circle cx="11" cy="11" r="8" />
+                  <path d="M21 21l-4.35-4.35" />
+                </svg>
+              </div>
               <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
-                No nearby matches yet. As more guests share their plans, matches
-                will appear here.
+                No nearby matches yet. As more guests share plans, matches will appear here.
               </p>
             </div>
           ) : (
-            <div className="space-y-2">
+            <div className="space-y-3">
               {overlaps.map((overlap) => (
                 <div
                   key={`${overlap.city}|${overlap.country}`}
-                  className="card p-4"
-                  style={{ borderLeft: '3px solid #C6A355' }}
+                  className="rounded-2xl overflow-hidden"
+                  style={{
+                    background: 'var(--bg-pure-white)',
+                    border: '1px solid var(--border-light)',
+                    boxShadow: '0 2px 8px rgba(0,0,0,0.03)',
+                  }}
                 >
-                  <p
-                    className="text-sm font-medium mb-1"
-                    style={{ color: 'var(--text-primary)' }}
+                  <div
+                    className="px-5 py-3 flex items-center justify-between"
+                    style={{
+                      background: 'linear-gradient(135deg, rgba(198,163,85,0.06), rgba(198,163,85,0.02))',
+                      borderBottom: '1px solid var(--border-light)',
+                    }}
                   >
-                    {overlap.city}, {overlap.country}
-                  </p>
-                  <p className="text-xs mb-3" style={{ color: 'var(--text-tertiary)' }}>
-                    You: {formatDate(overlap.your_dates.arrive)} &ndash;{' '}
-                    {formatDate(overlap.your_dates.depart)}
-                  </p>
-                  <div className="space-y-2">
+                    <div>
+                      <p
+                        className="text-base font-medium"
+                        style={{ fontFamily: 'var(--font-display)', color: 'var(--text-primary)' }}
+                      >
+                        {overlap.city}, {overlap.country}
+                      </p>
+                      <p className="text-xs mt-0.5" style={{ color: 'var(--text-tertiary)' }}>
+                        You: {formatDate(overlap.your_dates.arrive)} &ndash;{' '}
+                        {formatDate(overlap.your_dates.depart)}
+                      </p>
+                    </div>
+                    <span
+                      className="text-xs px-2.5 py-1 rounded-full font-medium"
+                      style={{
+                        background: 'linear-gradient(135deg, rgba(198,163,85,0.12), rgba(198,163,85,0.06))',
+                        color: 'var(--color-gold-dark)',
+                      }}
+                    >
+                      {overlap.overlapping_guests.length} {overlap.overlapping_guests.length === 1 ? 'match' : 'matches'}
+                    </span>
+                  </div>
+                  <div className="p-3 space-y-2">
                     {overlap.overlapping_guests.map((guest, i) => (
                       <div
                         key={i}
-                        className="flex items-center gap-3 p-2.5 rounded-lg"
-                        style={{ background: 'var(--bg-muted, #f9f8f6)' }}
+                        className="flex items-center gap-3 p-3 rounded-xl"
+                        style={{ background: 'var(--bg-warm-white)' }}
                       >
                         <div
-                          className="w-7 h-7 rounded-full flex items-center justify-center text-xs font-medium flex-shrink-0"
+                          className="w-9 h-9 rounded-full flex items-center justify-center text-xs font-semibold flex-shrink-0"
                           style={{
-                            background: 'linear-gradient(145deg, #A8883F, #C6A355)',
-                            color: 'white',
+                            background: 'linear-gradient(145deg, var(--color-gold-dark), var(--color-gold))',
+                            color: '#FDFBF7',
+                            boxShadow: '0 2px 6px rgba(198,163,85,0.25)',
                           }}
                         >
                           {guest.display_name.charAt(0)}
@@ -233,8 +328,11 @@ export default function TravelListView({
                         </div>
                         {guest.open_to_meetup && (
                           <span
-                            className="text-xs px-2 py-0.5 rounded-full flex-shrink-0"
-                            style={{ background: '#10b98120', color: '#10b981' }}
+                            className="text-[11px] font-medium px-2.5 py-1 rounded-full flex-shrink-0"
+                            style={{
+                              background: 'rgba(16,185,129,0.08)',
+                              color: '#059669',
+                            }}
                           >
                             Meetup
                           </span>
@@ -252,27 +350,52 @@ export default function TravelListView({
       {/* Ride Shares section */}
       {hasPlan && (
         <section>
-          <h2
-            className="text-base font-medium mb-3"
-            style={{ fontFamily: 'var(--font-display)', color: 'var(--text-primary)' }}
-          >
-            Ride Shares
-          </h2>
+          <div className="flex items-center gap-3 mb-4">
+            <div
+              className="w-8 h-8 rounded-lg flex items-center justify-center"
+              style={{ background: 'rgba(196,112,75,0.08)' }}
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--color-terracotta)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="10" />
+                <polyline points="12 6 12 12 16 14" />
+              </svg>
+            </div>
+            <h2
+              className="text-xl"
+              style={{ fontFamily: 'var(--font-display)', color: 'var(--text-primary)' }}
+            >
+              Ride Shares
+            </h2>
+          </div>
 
           {!mySharing ? (
             <div
-              className="card p-5 text-center"
-              style={{ background: 'var(--bg-muted, #f9f8f6)' }}
+              className="rounded-2xl p-6 text-center"
+              style={{
+                background: 'var(--bg-pure-white)',
+                border: '1px solid var(--border-light)',
+              }}
             >
+              <div
+                className="w-10 h-10 rounded-full flex items-center justify-center mx-auto mb-3"
+                style={{ background: 'rgba(196,112,75,0.06)' }}
+              >
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--color-terracotta)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M16 3h5v5M4 20L21 3M21 16v5h-5M15 15l6 6M4 4l5 5" />
+                </svg>
+              </div>
               <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
                 Enable &ldquo;share a ride&rdquo; in My Plan to see guests
-                arriving or departing within 2 hours of you.
+                arriving or departing near your time.
               </p>
             </div>
           ) : rideShares.length === 0 ? (
             <div
-              className="card p-5 text-center"
-              style={{ background: 'var(--bg-muted, #f9f8f6)' }}
+              className="rounded-2xl p-6 text-center"
+              style={{
+                background: 'var(--bg-pure-white)',
+                border: '1px solid var(--border-light)',
+              }}
             >
               <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
                 No ride matches yet. Make sure you&rsquo;ve added your arrival
@@ -280,42 +403,55 @@ export default function TravelListView({
               </p>
             </div>
           ) : (
-            <div className="space-y-2">
+            <div className="space-y-3">
               {rideShares.map((group, gi) => (
                 <div
                   key={gi}
-                  className="card p-4"
-                  style={{ borderLeft: '3px solid #D4B76A' }}
+                  className="rounded-2xl overflow-hidden"
+                  style={{
+                    background: 'var(--bg-pure-white)',
+                    border: '1px solid var(--border-light)',
+                    boxShadow: '0 2px 8px rgba(0,0,0,0.03)',
+                  }}
                 >
-                  <div className="flex items-center gap-2 mb-1">
+                  <div
+                    className="px-5 py-3 flex items-center gap-2"
+                    style={{
+                      background: group.type === 'arrival'
+                        ? 'linear-gradient(135deg, rgba(198,163,85,0.06), rgba(198,163,85,0.02))'
+                        : 'linear-gradient(135deg, rgba(16,185,129,0.06), rgba(16,185,129,0.02))',
+                      borderBottom: '1px solid var(--border-light)',
+                    }}
+                  >
                     <span
-                      className="text-xs px-2 py-0.5 rounded-full font-medium"
+                      className="text-xs px-2.5 py-1 rounded-full font-medium"
                       style={{
                         background: group.type === 'arrival' ? 'rgba(198,163,85,0.12)' : 'rgba(16,185,129,0.12)',
-                        color: group.type === 'arrival' ? '#A8883F' : '#10b981',
+                        color: group.type === 'arrival' ? 'var(--color-gold-dark)' : '#059669',
                       }}
                     >
                       {group.type === 'arrival' ? 'Arriving' : 'Departing'}
                     </span>
-                    <span className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
+                    <p className="text-sm font-medium" style={{ fontFamily: 'var(--font-display)', color: 'var(--text-primary)' }}>
                       {group.city}
-                    </span>
+                    </p>
+                    <p className="text-xs ml-auto" style={{ color: 'var(--text-tertiary)' }}>
+                      {formatDate(group.your_date)} at {formatTime(group.your_time)}
+                    </p>
                   </div>
-                  <p className="text-xs mb-3" style={{ color: 'var(--text-tertiary)' }}>
-                    You: {formatDate(group.your_date)} at {formatTime(group.your_time)}
-                  </p>
-                  <div className="space-y-2">
+                  <div className="p-3 space-y-2">
                     {group.matches.map((match, i) => (
                       <div
                         key={i}
-                        className="flex items-start gap-3 p-2.5 rounded-lg"
-                        style={{ background: 'var(--bg-muted, #f9f8f6)' }}
+                        className="flex items-start gap-3 p-3 rounded-xl"
+                        style={{ background: 'var(--bg-warm-white)' }}
                       >
                         <div
-                          className="w-7 h-7 rounded-full flex items-center justify-center text-xs font-medium flex-shrink-0"
+                          className="w-9 h-9 rounded-full flex items-center justify-center text-xs font-semibold flex-shrink-0"
                           style={{
-                            background: 'linear-gradient(145deg, #A8883F, #D4B76A)',
-                            color: 'white',
+                            background: 'linear-gradient(145deg, var(--color-gold-dark), var(--color-gold))',
+                            color: '#FDFBF7',
+                            boxShadow: '0 2px 6px rgba(198,163,85,0.25)',
                           }}
                         >
                           {match.display_name.charAt(0)}
@@ -334,7 +470,7 @@ export default function TravelListView({
                             {match.origin_city && ` \u00b7 from ${match.origin_city}`}
                           </p>
                           {match.share_contact && (
-                            <p className="text-xs mt-1 font-medium" style={{ color: '#C6A355' }}>
+                            <p className="text-xs mt-1 font-medium" style={{ color: 'var(--color-gold-dark)' }}>
                               {match.share_contact}
                             </p>
                           )}
@@ -349,124 +485,139 @@ export default function TravelListView({
         </section>
       )}
 
-      {/* Prompt to add plan */}
-      {hasPlan === false && (
-        <div
-          className="card p-5 text-center"
-          style={{ borderLeft: '3px solid #C6A355' }}
-        >
-          <p className="text-sm mb-3" style={{ color: 'var(--text-secondary)' }}>
-            Share your travel plans to see who&rsquo;ll be nearby!
-          </p>
-          <button
-            onClick={onAddPlan}
-            className="px-5 py-2.5 rounded-full text-sm font-medium"
-            style={{
-              background: 'linear-gradient(135deg, #A8883F, #C6A355, #D4B76A)',
-              color: '#FDFBF7',
-              boxShadow: '0 4px 16px rgba(198,163,85,0.25)',
-            }}
-          >
-            Add My Travel Plans
-          </button>
-        </div>
-      )}
-
       {/* Where Everyone Is Traveling */}
       <section>
-        <div className="flex items-center gap-2 mb-4">
+        <div className="flex items-center gap-3 mb-4">
           <div
-            style={{
-              width: 20,
-              height: 1,
-              background: 'linear-gradient(90deg, transparent, rgba(198,163,85,0.5))',
-            }}
-          />
-          <h2
-            style={{
-              fontSize: 10,
-              fontWeight: 500,
-              letterSpacing: '0.14em',
-              textTransform: 'uppercase',
-              color: '#C6A355',
-              fontFamily: 'var(--font-body)',
-              margin: 0,
-            }}
+            className="w-8 h-8 rounded-lg flex items-center justify-center"
+            style={{ background: 'rgba(122,139,92,0.08)' }}
           >
-            Where Everyone Is Traveling
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--color-olive)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="10" />
+              <path d="M2 12h20M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z" />
+            </svg>
+          </div>
+          <h2
+            className="text-xl"
+            style={{ fontFamily: 'var(--font-display)', color: 'var(--text-primary)' }}
+          >
+            Guest Destinations
           </h2>
-          <div
-            style={{
-              flex: 1,
-              height: 1,
-              background: 'linear-gradient(90deg, rgba(198,163,85,0.5), transparent)',
-            }}
-          />
+          {stops.length > 0 && (
+            <span
+              className="text-xs px-2.5 py-1 rounded-full ml-auto"
+              style={{
+                background: 'rgba(122,139,92,0.08)',
+                color: 'var(--color-olive)',
+                fontWeight: 500,
+              }}
+            >
+              {stops.reduce((sum, s) => sum + s.guest_count, 0)} travelers
+            </span>
+          )}
         </div>
 
         {stops.length > 0 && (
-          <input
-            type="text"
-            value={citySearch}
-            onChange={(e) => setCitySearch(e.target.value)}
-            placeholder="Search by city or country..."
-            className="w-full px-3 py-2 rounded-lg text-sm mb-3"
-            style={{
-              background: 'var(--bg-muted, #f9f8f6)',
-              border: '1px solid var(--border-light)',
-              color: 'var(--text-primary)',
-              outline: 'none',
-            }}
-          />
+          <div
+            className="relative mb-4"
+          >
+            <svg
+              className="absolute left-3.5 top-1/2 -translate-y-1/2"
+              width="16" height="16" viewBox="0 0 24 24" fill="none"
+              stroke="var(--text-tertiary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+            >
+              <circle cx="11" cy="11" r="8" />
+              <path d="M21 21l-4.35-4.35" />
+            </svg>
+            <input
+              type="text"
+              value={citySearch}
+              onChange={(e) => setCitySearch(e.target.value)}
+              placeholder="Search by city or country..."
+              className="w-full pl-10 pr-4 py-3 rounded-xl text-sm"
+              style={{
+                background: 'var(--bg-pure-white)',
+                border: '1px solid var(--border-light)',
+                color: 'var(--text-primary)',
+                outline: 'none',
+                boxShadow: '0 1px 4px rgba(0,0,0,0.03)',
+              }}
+            />
+          </div>
         )}
 
         {stops.length === 0 ? (
           <div
-            className="card p-5 text-center"
-            style={{ background: 'var(--bg-muted, #f9f8f6)' }}
+            className="rounded-2xl p-8 text-center"
+            style={{
+              background: 'var(--bg-pure-white)',
+              border: '1px solid var(--border-light)',
+            }}
           >
+            <div
+              className="w-12 h-12 rounded-full flex items-center justify-center mx-auto mb-3"
+              style={{ background: 'rgba(122,139,92,0.06)' }}
+            >
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="var(--color-olive)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="10" />
+                <path d="M2 12h20M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z" />
+              </svg>
+            </div>
             <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
               No travel plans shared yet. Be the first!
             </p>
           </div>
         ) : filteredStops.length === 0 ? (
           <div
-            className="card p-5 text-center"
-            style={{ background: 'var(--bg-muted, #f9f8f6)' }}
+            className="rounded-2xl p-6 text-center"
+            style={{
+              background: 'var(--bg-pure-white)',
+              border: '1px solid var(--border-light)',
+            }}
           >
             <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
               No cities match &ldquo;{citySearch}&rdquo;
             </p>
           </div>
         ) : (
-          <div className="space-y-2">
+          <div className="space-y-3">
             {filteredStops.map((stop) => (
               <div
                 key={`${stop.city}|${stop.country}`}
-                className="card p-4"
+                className="rounded-2xl overflow-hidden"
+                style={{
+                  background: 'var(--bg-pure-white)',
+                  border: '1px solid var(--border-light)',
+                  boxShadow: '0 2px 8px rgba(0,0,0,0.03)',
+                }}
               >
-                <div className="flex items-center justify-between mb-2">
+                <div
+                  className="px-5 py-3.5 flex items-center justify-between"
+                  style={{
+                    background: 'linear-gradient(135deg, rgba(122,139,92,0.05), rgba(122,139,92,0.01))',
+                    borderBottom: '1px solid var(--border-light)',
+                  }}
+                >
                   <div>
                     <p
-                      className="text-sm font-medium"
+                      className="text-base font-medium"
                       style={{ fontFamily: 'var(--font-display)', color: 'var(--text-primary)' }}
                     >
                       {stop.city}, {stop.country}
                     </p>
-                    {/* Show context label based on stop types */}
                     {(() => {
                       const allOrigin = stop.guests.every((g) => g.stop_type === 'origin');
                       const someOrigin = stop.guests.some((g) => g.stop_type === 'origin');
                       if (allOrigin) {
                         return (
-                          <p className="text-[11px] mt-0.5" style={{ color: 'var(--text-tertiary)' }}>
+                          <p className="text-xs mt-0.5" style={{ color: 'var(--text-tertiary)', fontStyle: 'italic' }}>
                             Departing from
                           </p>
                         );
                       }
                       if (someOrigin) {
                         return (
-                          <p className="text-[11px] mt-0.5" style={{ color: 'var(--text-tertiary)' }}>
+                          <p className="text-xs mt-0.5" style={{ color: 'var(--text-tertiary)', fontStyle: 'italic' }}>
                             Departing &amp; visiting
                           </p>
                         );
@@ -475,100 +626,129 @@ export default function TravelListView({
                     })()}
                   </div>
                   <span
-                    className="text-xs px-2 py-0.5 rounded-full"
+                    className="text-xs px-2.5 py-1 rounded-full font-medium"
                     style={{
-                      background: 'var(--bg-muted, #f5f3f0)',
-                      color: 'var(--text-secondary)',
+                      background: 'rgba(122,139,92,0.08)',
+                      color: 'var(--color-olive)',
                     }}
                   >
                     {stop.guest_count} {stop.guest_count === 1 ? 'guest' : 'guests'}
                   </span>
                 </div>
-                <div className="flex flex-wrap gap-1.5">
+                <div className="p-3 space-y-1">
                   {stop.guests.map((guest, i) => {
                     const isExpanded = expandedGuest === `${guest.guest_id}-${stop.city}`;
                     const itinerary = guestItineraries.get(guest.guest_id);
 
                     return (
-                      <div key={`${guest.guest_id}-${i}`} className="w-full">
+                      <div key={`${guest.guest_id}-${i}`}>
                         <button
                           onClick={() =>
                             setExpandedGuest(
                               isExpanded ? null : `${guest.guest_id}-${stop.city}`
                             )
                           }
-                          className="flex items-center gap-1.5 px-2 py-1 rounded-full text-xs text-left"
+                          className="w-full flex items-center gap-3 p-3 rounded-xl text-left transition-colors"
                           style={{
                             background: isExpanded
-                              ? 'linear-gradient(145deg, #A8883F, #C6A355)'
-                              : 'var(--bg-muted, #f9f8f6)',
+                              ? 'linear-gradient(135deg, rgba(198,163,85,0.1), rgba(198,163,85,0.04))'
+                              : 'var(--bg-warm-white)',
                           }}
                         >
                           <div
-                            className="w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-medium flex-shrink-0"
+                            className="w-9 h-9 rounded-full flex items-center justify-center text-xs font-semibold flex-shrink-0"
                             style={{
-                              background: isExpanded ? 'rgba(255,255,255,0.3)' : 'linear-gradient(145deg, #A8883F, #C6A355)',
-                              color: 'white',
+                              background: isExpanded
+                                ? 'linear-gradient(145deg, var(--color-gold-dark), var(--color-gold))'
+                                : 'linear-gradient(145deg, rgba(198,163,85,0.15), rgba(198,163,85,0.08))',
+                              color: isExpanded ? '#FDFBF7' : 'var(--color-gold-dark)',
+                              boxShadow: isExpanded ? '0 2px 6px rgba(198,163,85,0.25)' : 'none',
                             }}
                           >
                             {guest.display_name.charAt(0)}
                           </div>
-                          <span style={{ color: isExpanded ? 'white' : 'var(--text-primary)' }}>
-                            {guest.display_name}
-                          </span>
-                          {!isExpanded && guest.arrive_date && (
-                            <span style={{ color: 'var(--text-tertiary)' }}>
-                              {formatDate(guest.arrive_date)}
-                              {guest.depart_date ? `\u2013${formatDate(guest.depart_date)}` : ''}
-                            </span>
-                          )}
+                          <div className="flex-1 min-w-0">
+                            <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
+                              {guest.display_name}
+                            </p>
+                            {!isExpanded && guest.arrive_date && (
+                              <p className="text-xs" style={{ color: 'var(--text-tertiary)' }}>
+                                {formatDate(guest.arrive_date)}
+                                {guest.depart_date ? ` \u2013 ${formatDate(guest.depart_date)}` : ''}
+                              </p>
+                            )}
+                          </div>
+                          <svg
+                            width="16" height="16" viewBox="0 0 24 24" fill="none"
+                            stroke="var(--text-tertiary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+                            className="flex-shrink-0 transition-transform duration-200"
+                            style={{ transform: isExpanded ? 'rotate(180deg)' : 'rotate(0deg)' }}
+                          >
+                            <polyline points="6 9 12 15 18 9" />
+                          </svg>
                         </button>
 
                         {isExpanded && itinerary && (
                           <div
-                            className="mt-1 mb-2 ml-3 p-3 rounded-lg text-xs space-y-2"
-                            style={{ background: 'var(--bg-muted, #f9f8f6)' }}
+                            className="mt-1 mb-2 mx-3 p-4 rounded-xl text-xs space-y-3"
+                            style={{
+                              background: 'var(--bg-warm-white)',
+                              border: '1px solid var(--border-light)',
+                            }}
                           >
-                            <p className="font-medium" style={{ color: 'var(--text-primary)' }}>
-                              {guest.display_name}&apos;s travel plan
+                            <p
+                              className="font-medium text-sm"
+                              style={{ fontFamily: 'var(--font-display)', color: 'var(--text-primary)' }}
+                            >
+                              {guest.display_name}&apos;s journey
                             </p>
-                            {itinerary.stops.map((s, si) => (
+                            <div className="relative pl-4">
                               <div
-                                key={si}
-                                className="flex items-start gap-2"
-                              >
+                                className="absolute left-[3px] top-2 bottom-2 w-px"
+                                style={{ background: 'var(--border-light)' }}
+                              />
+                              {itinerary.stops.map((s, si) => (
                                 <div
-                                  className="w-1.5 h-1.5 rounded-full mt-1.5 flex-shrink-0"
-                                  style={{
-                                    background: s.city === stop.city
-                                      ? '#C6A355'
-                                      : 'var(--text-tertiary)',
-                                  }}
-                                />
-                                <div>
-                                  <p style={{
-                                    color: 'var(--text-primary)',
-                                    fontWeight: s.city === stop.city ? 600 : 400,
-                                  }}>
-                                    {s.stop_type === 'origin' ? 'Departing from ' : ''}
-                                    {s.city}, {s.country}
-                                  </p>
-                                  {s.arrive_date && (
-                                    <p style={{ color: 'var(--text-secondary)' }}>
-                                      {formatDate(s.arrive_date)}
-                                      {s.depart_date ? ` \u2013 ${formatDate(s.depart_date)}` : ''}
+                                  key={si}
+                                  className="flex items-start gap-3 pb-3 last:pb-0 relative"
+                                >
+                                  <div
+                                    className="w-2 h-2 rounded-full mt-1 flex-shrink-0 -ml-[5px]"
+                                    style={{
+                                      background: s.city === stop.city
+                                        ? 'var(--color-gold)'
+                                        : 'var(--text-tertiary)',
+                                      boxShadow: s.city === stop.city ? '0 0 0 3px rgba(198,163,85,0.15)' : 'none',
+                                    }}
+                                  />
+                                  <div>
+                                    <p style={{
+                                      color: 'var(--text-primary)',
+                                      fontWeight: s.city === stop.city ? 600 : 400,
+                                    }}>
+                                      {s.stop_type === 'origin' ? 'Departing from ' : ''}
+                                      {s.city}, {s.country}
                                     </p>
-                                  )}
-                                  {s.notes && (
-                                    <p style={{ color: 'var(--text-tertiary)', fontStyle: 'italic' }}>
-                                      {s.notes}
-                                    </p>
-                                  )}
+                                    {s.arrive_date && (
+                                      <p style={{ color: 'var(--text-secondary)' }}>
+                                        {formatDate(s.arrive_date)}
+                                        {s.depart_date ? ` \u2013 ${formatDate(s.depart_date)}` : ''}
+                                      </p>
+                                    )}
+                                    {s.notes && (
+                                      <p style={{ color: 'var(--text-tertiary)', fontStyle: 'italic' }}>
+                                        {s.notes}
+                                      </p>
+                                    )}
+                                  </div>
                                 </div>
-                              </div>
-                            ))}
+                              ))}
+                            </div>
                             {guest.open_to_meetup && (
-                              <p style={{ color: '#10b981' }}>
+                              <p
+                                className="font-medium"
+                                style={{ color: '#059669' }}
+                              >
                                 Open to meetups
                               </p>
                             )}


### PR DESCRIPTION
- Tab bar: gold gradient active state with icons, white card container
- CTA card: bento-style tile with icon, title, description, and arrow
- City cards: rounded-2xl with gradient headers, proper avatars, chevron expand
- Search: icon-prefixed input with subtle shadow
- Section headers: display font with icon badges and count pills
- Arrivals: refined cards with gradient avatars and transport badges
- Empty states: centered icon + text in bordered containers
- Consistent use of --bg-pure-white, --border-light, var(--font-display)

https://claude.ai/code/session_01A3JYPt5VgMUGZqzfzo28qB