### PR TITLE
Fix traveler count to use unique guests instead of summing per-stop c…

### DIFF
--- a/components/travel/TravelListView.tsx
+++ b/components/travel/TravelListView.tsx
@@ -512,7 +512,7 @@ export default function TravelListView({
                 fontWeight: 500,
               }}
             >
-              {stops.reduce((sum, s) => sum + s.guest_count, 0)} travelers
+              {new Set(stops.flatMap((s) => s.guests.map((g) => g.guest_id))).size} travelers
             </span>
           )}
         </div>


### PR DESCRIPTION
…ounts

A guest appearing in multiple cities was counted once per city. Now uses a Set of guest_ids to get the true unique traveler count.

https://claude.ai/code/session_01A3JYPt5VgMUGZqzfzo28qB