### PR TITLE
Always append planner contact to FAQ chatbot replies, add ConfirmDialog

### DIFF
--- a/app/api/v1/w/[slug]/faq/route.ts
+++ b/app/api/v1/w/[slug]/faq/route.ts
@@ -12,6 +12,27 @@ const askSchema = z.object({
   question: z.string().min(2).max(500),
 });
 
+/**
+ * Appends a "still need help? email the planner" line to every chatbot
+ * response when the couple has configured a wedding planner contact. Done
+ * programmatically (rather than via the system prompt) so the line is
+ * deterministic and survives cache hits without getting stale.
+ */
+function appendPlannerLine(
+  answer: string,
+  plannerName: string | null,
+  plannerEmail: string | null
+): string {
+  if (!plannerEmail) return answer;
+  // Don't double-append if the answer already contains the planner email
+  // (e.g. the AI already wove it in naturally).
+  if (answer.includes(plannerEmail)) return answer;
+  const line = plannerName
+    ? `Still need help? Email ${plannerName} at ${plannerEmail}.`
+    : `Still need help? Email our wedding planner at ${plannerEmail}.`;
+  return `${answer.trimEnd()}\n\n${line}`;
+}
+
 // POST /api/v1/w/[slug]/faq — ask a question
 export async function POST(
   request: NextRequest,
@@ -60,6 +81,16 @@ export async function POST(
 
     const question = sanitizeText(parsed.data.question);
 
+    // Extract wedding config + planner early — we need the planner contact
+    // for both cache-hit and fresh responses (it's appended to every reply).
+    const wedding = weddingResult.rows[0];
+    const weddingName = wedding.display_name;
+    const weddingConfigObj = wedding.config || {};
+    const knowledgeBase: string =
+      typeof weddingConfigObj.knowledge_base === 'string' ? weddingConfigObj.knowledge_base.trim() : '';
+    const plannerEmail: string | null = weddingConfigObj.wedding_planner?.email || null;
+    const plannerName: string | null = weddingConfigObj.wedding_planner?.name || null;
+
     // Get FAQ entries and events for this wedding
     const [faqResult, eventsResult] = await Promise.all([
       pool.query(
@@ -94,7 +125,9 @@ export async function POST(
 
       return Response.json({
         data: {
-          answer: cachedAnswer,
+          // Append planner line on-read so updated planner contact is always
+          // fresh (cached answers store only the raw AI output).
+          answer: appendPlannerLine(cachedAnswer, plannerName, plannerEmail),
           cached: true,
           sources: [],
         },
@@ -109,13 +142,6 @@ export async function POST(
       );
     }
 
-    const wedding = weddingResult.rows[0];
-    const weddingName = wedding.display_name;
-    const weddingConfigObj = wedding.config || {};
-    const knowledgeBase: string =
-      typeof weddingConfigObj.knowledge_base === 'string' ? weddingConfigObj.knowledge_base.trim() : '';
-    const plannerEmail: string | null = weddingConfigObj.wedding_planner?.email || null;
-    const plannerName: string | null = weddingConfigObj.wedding_planner?.name || null;
     const hasContext =
       faqResult.rows.length > 0 ||
       eventsResult.rows.length > 0 ||
@@ -127,10 +153,9 @@ export async function POST(
       answer = `Here's what I know about "${question}" for ${weddingName}: This is a mock FAQ response. Please check with the couple for specific details.`;
       sources = faqResult.rows.slice(0, 2).map((r) => ({ question: r.question, answer: r.answer }));
     } else if (!hasContext) {
-      const fallback = plannerEmail
-        ? ` You can email ${plannerName || 'our wedding planner'} at ${plannerEmail} and they'll get back to you.`
-        : ' You might want to reach out to them directly!';
-      answer = `I don't have specific information about that yet. The couple hasn't added FAQ entries.${fallback}`;
+      // Raw fallback — the planner line is appended below via appendPlannerLine
+      // so guests always see a way to reach the planner when configured.
+      answer = "I don't have specific information about that yet. The couple hasn't added FAQ entries.";
     } else {
       // Build rich context from FAQ entries + events + wedding details + knowledge base
       const openai = getOpenAIClient();
@@ -190,16 +215,15 @@ export async function POST(
 
       const fullContext = contextParts.join('\n\n---\n\n');
 
-      const fallbackInstruction = plannerEmail
-        ? ` If the provided context does not contain enough information to answer the question, say so honestly in one sentence and tell the guest to email ${plannerName || 'our wedding planner'} at ${plannerEmail}. Do not include any other contact info.`
-        : " If you're not sure, say so honestly and suggest they ask the couple directly.";
-
+      // We programmatically append the planner contact to every response
+      // (see appendPlannerLine below), so the system prompt just tells the
+      // AI to be honest when it doesn't know and avoid making things up.
       const chatResponse = await openai.chat.completions.create({
         model: CHAT_MODEL_MINI,
         messages: [
           {
             role: 'system',
-            content: `You are a friendly, helpful assistant for ${weddingName}. Answer guest questions based on the provided wedding information, event schedule, FAQ entries, and additional wedding info. Be warm, concise, and conversational.${fallbackInstruction} Never make up specific details that aren't in the context.`,
+            content: `You are a friendly, helpful assistant for ${weddingName}. Answer guest questions based on the provided wedding information, event schedule, FAQ entries, and additional wedding info. Be warm, concise, and conversational. If the provided context does not contain enough information to answer the question, say so honestly in one sentence. Never make up specific details that aren't in the context. Do not include contact info in your answer — it is appended separately.`,
           },
           {
             role: 'user',
@@ -213,7 +237,9 @@ export async function POST(
       answer = chatResponse.choices[0]?.message?.content || "I'm not sure about that. You might want to ask the couple directly!";
     }
 
-    // Only cache AI-generated answers, not fallback messages
+    // Only cache AI-generated answers, not fallback messages. Cache the RAW
+    // answer (without the planner line) so planner contact stays fresh when
+    // the couple updates it in the Knowledge page.
     if (hasContext) {
       await pool.query(
         `INSERT INTO faq_cache (wedding_id, question_hash, answer)
@@ -225,7 +251,7 @@ export async function POST(
 
     return Response.json({
       data: {
-        answer,
+        answer: appendPlannerLine(answer, plannerName, plannerEmail),
         cached: false,
         sources,
       },

--- a/components/ui/ConfirmDialog.tsx
+++ b/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import { useEffect, useState, type ReactNode } from 'react';
+
+export interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  description: ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** 'danger' styles the confirm button red (for destructive ops). */
+  variant?: 'danger' | 'primary';
+  onConfirm: () => Promise<void> | void;
+  onCancel: () => void;
+}
+
+/**
+ * Styled "are you sure?" modal for destructive (and other high-consequence)
+ * operations. Replaces `window.confirm()` so confirmations match the app's
+ * visual language and are consistent across the product.
+ */
+export default function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  variant = 'danger',
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      setBusy(false);
+      return;
+    }
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !busy) onCancel();
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [open, busy, onCancel]);
+
+  if (!open) return null;
+
+  const handleConfirm = async () => {
+    setBusy(true);
+    try {
+      await onConfirm();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const confirmBackground =
+    variant === 'danger'
+      ? 'linear-gradient(135deg, #B44A2B, #C4704B)'
+      : 'linear-gradient(135deg, var(--color-gold-dark), var(--color-gold))';
+  const confirmShadow =
+    variant === 'danger'
+      ? '0 2px 10px rgba(180, 74, 43, 0.25)'
+      : '0 2px 8px rgba(198, 163, 85, 0.25)';
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(27, 28, 26, 0.45)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 100,
+        padding: 20,
+        backdropFilter: 'blur(2px)',
+      }}
+      onClick={() => !busy && onCancel()}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirm-dialog-title"
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: 'var(--bg-pure-white)',
+          borderRadius: 18,
+          padding: 28,
+          maxWidth: 440,
+          width: '100%',
+          boxShadow: '0 20px 50px rgba(0,0,0,0.18)',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 14, marginBottom: 14 }}>
+          <div
+            style={{
+              width: 40,
+              height: 40,
+              borderRadius: 12,
+              background: variant === 'danger' ? 'rgba(196,112,75,0.1)' : 'rgba(198,163,85,0.1)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexShrink: 0,
+            }}
+          >
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke={variant === 'danger' ? 'var(--color-terracotta)' : 'var(--color-gold-dark)'}
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+              <line x1="12" y1="9" x2="12" y2="13" />
+              <line x1="12" y1="17" x2="12.01" y2="17" />
+            </svg>
+          </div>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <h3
+              id="confirm-dialog-title"
+              style={{
+                fontFamily: 'var(--font-display)',
+                fontSize: 20,
+                fontWeight: 500,
+                margin: '0 0 6px',
+                color: 'var(--text-primary)',
+                lineHeight: 1.3,
+              }}
+            >
+              {title}
+            </h3>
+            <div
+              style={{
+                fontSize: 14,
+                color: 'var(--text-secondary)',
+                margin: 0,
+                fontFamily: 'var(--font-body)',
+                lineHeight: 1.55,
+              }}
+            >
+              {description}
+            </div>
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end', marginTop: 20 }}>
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={busy}
+            style={{
+              padding: '10px 20px',
+              borderRadius: 10,
+              border: '1px solid var(--border-light)',
+              background: 'var(--bg-pure-white)',
+              color: 'var(--text-secondary)',
+              fontSize: 14,
+              fontFamily: 'var(--font-body)',
+              cursor: busy ? 'default' : 'pointer',
+              opacity: busy ? 0.6 : 1,
+            }}
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={busy}
+            style={{
+              padding: '10px 24px',
+              borderRadius: 10,
+              border: 'none',
+              background: confirmBackground,
+              color: '#FDFBF7',
+              fontSize: 14,
+              fontWeight: 500,
+              fontFamily: 'var(--font-body)',
+              cursor: busy ? 'default' : 'pointer',
+              opacity: busy ? 0.75 : 1,
+              boxShadow: confirmShadow,
+            }}
+          >
+            {busy ? 'Working…' : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tests/unit/components/WeddingProvider.test.tsx
+++ b/tests/unit/components/WeddingProvider.test.tsx
@@ -75,6 +75,7 @@ describe('WeddingProvider', () => {
       venue_country: null,
       venue_lat: null,
       venue_lng: null,
+      wedding_planner: null,
       features: {
         social_feed: false,
         faq_chatbot: false,


### PR DESCRIPTION
The FAQ chatbot previously only mentioned the wedding planner on fallback responses. Now every reply (cache hits, AI answers, and no-context fallbacks) programmatically appends "Still need help? Email [name] at [email]." when the couple has configured a planner in the Knowledge page. Cached answers store the raw AI output so planner contact stays fresh if the couple updates it.

Also adds components/ui/ConfirmDialog.tsx — a styled replacement for window.confirm() used by upcoming destructive-op guards in the dashboard and guest pages.

https://claude.ai/code/session_01A3JYPt5VgMUGZqzfzo28qB