### PR TITLE
Expand dress_code limit and promote it to a textarea

### DIFF
--- a/app/api/v1/dashboard/weddings/[weddingId]/events/[eventId]/route.ts
+++ b/app/api/v1/dashboard/weddings/[weddingId]/events/[eventId]/route.ts
@@ -13,7 +13,7 @@ const updateEventSchema = z.object({
   end_date: z.string().optional().or(z.null()),
   venue_name: z.string().max(200).optional().or(z.null()),
   venue_address: z.string().max(500).optional().or(z.null()),
-  dress_code: z.string().max(100).optional().or(z.null()),
+  dress_code: z.string().max(1000).optional().or(z.null()),
   description: z.string().max(2000).optional().or(z.null()),
   logistics: z.string().max(2000).optional().or(z.null()),
   accent_color: z.string().max(20).optional().or(z.null()),

--- a/app/api/v1/dashboard/weddings/[weddingId]/events/route.ts
+++ b/app/api/v1/dashboard/weddings/[weddingId]/events/route.ts
@@ -13,7 +13,7 @@ const createEventSchema = z.object({
   end_date: z.string().optional(),
   venue_name: z.string().max(200).optional(),
   venue_address: z.string().max(500).optional(),
-  dress_code: z.string().max(100).optional(),
+  dress_code: z.string().max(1000).optional(),
   description: z.string().max(2000).optional(),
   logistics: z.string().max(2000).optional(),
   accent_color: z.string().max(20).optional(),

--- a/app/dashboard/[weddingId]/settings/page.tsx
+++ b/app/dashboard/[weddingId]/settings/page.tsx
@@ -481,20 +481,24 @@ export default function SettingsPage({ params }: { params: Promise<{ weddingId: 
             </div>
           </div>
 
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16, marginBottom: 16 }}>
-            <div>
-              <label style={labelStyle}>Venue Name</label>
-              <input style={inputStyle} value={venueName} onChange={(e) => setVenueName(e.target.value)} placeholder="e.g., The Grand Ballroom" />
-            </div>
-            <div>
-              <label style={labelStyle}>Dress Code</label>
-              <input style={inputStyle} value={dressCode} onChange={(e) => setDressCode(e.target.value)} placeholder="e.g., Black Tie, Formal" />
-            </div>
+          <div style={{ marginBottom: 16 }}>
+            <label style={labelStyle}>Venue Name</label>
+            <input style={inputStyle} value={venueName} onChange={(e) => setVenueName(e.target.value)} placeholder="e.g., The Grand Ballroom" />
           </div>
 
           <div style={{ marginBottom: 16 }}>
             <label style={labelStyle}>Venue Address</label>
             <input style={inputStyle} value={venueAddress} onChange={(e) => setVenueAddress(e.target.value)} placeholder="123 Main St, City, State" />
+          </div>
+
+          <div style={{ marginBottom: 16 }}>
+            <label style={labelStyle}>Dress Code</label>
+            <textarea
+              style={{ ...inputStyle, minHeight: 60, resize: 'vertical' }}
+              value={dressCode}
+              onChange={(e) => setDressCode(e.target.value)}
+              placeholder="e.g., Black tie, or a longer note about what to wear..."
+            />
           </div>
 
           <div style={{ marginBottom: 16 }}>


### PR DESCRIPTION
Bump the Zod max from 100 to 1000 on both create and update event endpoints — the 100-char cap was choking on anything beyond "Black Tie, Formal". Swap the dashboard form's single-line input for a resizable textarea in its own row so couples can write a real description of what to wear.

https://claude.ai/code/session_01A3JYPt5VgMUGZqzfzo28qB