### PR TITLE
Add "traveling with" feature to travel plans

### DIFF
--- a/app/api/v1/w/[slug]/travel/arrivals/route.ts
+++ b/app/api/v1/w/[slug]/travel/arrivals/route.ts
@@ -17,7 +17,8 @@ export async function GET(
          ts.stop_type, ts.arrive_date, ts.depart_date, ts.arrive_time, ts.depart_time,
          ts.transport_mode, ts.transport_details,
          g.id AS guest_id, g.display_name,
-         tp.share_transport, tp.origin_city
+         tp.share_transport, tp.origin_city,
+         tp.traveling_with_guest_ids
        FROM travel_stops ts
        JOIN travel_plans tp ON ts.plan_id = tp.id
        JOIN guests g ON tp.guest_id = g.id
@@ -27,6 +28,28 @@ export async function GET(
        ORDER BY ts.arrive_date ASC, ts.arrive_time ASC`,
       [weddingId]
     );
+
+    // Collect all companion IDs for batch name resolution
+    const allCompanionIds = new Set<string>();
+    for (const row of result.rows) {
+      if (row.traveling_with_guest_ids) {
+        for (const id of row.traveling_with_guest_ids) {
+          allCompanionIds.add(id);
+        }
+      }
+    }
+
+    // Resolve companion names
+    const companionNames = new Map<string, string>();
+    if (allCompanionIds.size > 0) {
+      const namesResult = await pool.query(
+        'SELECT id, display_name FROM guests WHERE id = ANY($1)',
+        [Array.from(allCompanionIds)]
+      );
+      for (const row of namesResult.rows) {
+        companionNames.set(row.id, row.display_name);
+      }
+    }
 
     const arrivals = result.rows.map((row) => ({
       guest_id: row.guest_id,
@@ -40,6 +63,9 @@ export async function GET(
       transport_details: row.transport_details,
       share_transport: row.share_transport,
       origin_city: row.origin_city,
+      traveling_with: (row.traveling_with_guest_ids || [])
+        .map((id: string) => ({ id, display_name: companionNames.get(id) || 'Guest' }))
+        .filter((c: { id: string }) => c.id !== row.guest_id),
     }));
 
     return Response.json({ data: { arrivals } });

--- a/app/api/v1/w/[slug]/travel/my-plan/route.ts
+++ b/app/api/v1/w/[slug]/travel/my-plan/route.ts
@@ -15,13 +15,15 @@ export async function GET(
 
     const planResult = await pool.query(
       `SELECT id, plan_type, origin_city, origin_lat, origin_lng, origin_country,
-              share_transport, share_contact, visibility, notes, created_at, updated_at
+              share_transport, share_contact, visibility, notes,
+              traveling_with_guest_ids,
+              created_at, updated_at
        FROM travel_plans WHERE wedding_id = $1 AND guest_id = $2`,
       [weddingId, guestId]
     );
 
     if (planResult.rows.length === 0) {
-      return Response.json({ data: { plan: null } });
+      return Response.json({ data: { plan: null, guest_id: guestId } });
     }
 
     const plan = planResult.rows[0];
@@ -42,9 +44,20 @@ export async function GET(
       depart_date: toDateString(s.depart_date),
     }));
 
+    // Resolve companion names
+    let travelingWith: Array<{ id: string; first_name: string; last_name: string; display_name: string }> = [];
+    if (plan.traveling_with_guest_ids?.length > 0) {
+      const namesResult = await pool.query(
+        'SELECT id, first_name, last_name, display_name FROM guests WHERE id = ANY($1)',
+        [plan.traveling_with_guest_ids]
+      );
+      travelingWith = namesResult.rows;
+    }
+
     return Response.json({
       data: {
-        plan: { ...plan, stops },
+        plan: { ...plan, stops, traveling_with: travelingWith },
+        guest_id: guestId,
       },
     });
   } catch (error) {
@@ -68,12 +81,23 @@ export async function PUT(
     }
 
     const data = parsed.data;
+    const companionIds = (data.traveling_with_guest_ids || []).filter((id) => id !== guestId);
+
+    // Verify companions belong to this wedding
+    let validCompanionIds: string[] = [];
+    if (companionIds.length > 0) {
+      const checkResult = await pool.query(
+        'SELECT id FROM guests WHERE id = ANY($1) AND wedding_id = $2',
+        [companionIds, weddingId]
+      );
+      validCompanionIds = checkResult.rows.map((r) => r.id);
+    }
 
     // Upsert travel plan
     const planResult = await pool.query(
       `INSERT INTO travel_plans (wedding_id, guest_id, plan_type, origin_city, origin_lat, origin_lng,
-         origin_country, share_transport, share_contact, visibility, notes)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+         origin_country, share_transport, share_contact, visibility, notes, traveling_with_guest_ids)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
        ON CONFLICT (wedding_id, guest_id) DO UPDATE SET
          plan_type = EXCLUDED.plan_type,
          origin_city = EXCLUDED.origin_city,
@@ -84,9 +108,11 @@ export async function PUT(
          share_contact = EXCLUDED.share_contact,
          visibility = EXCLUDED.visibility,
          notes = EXCLUDED.notes,
+         traveling_with_guest_ids = EXCLUDED.traveling_with_guest_ids,
          updated_at = NOW()
        RETURNING id, plan_type, origin_city, origin_lat, origin_lng, origin_country,
-                 share_transport, share_contact, visibility, notes, created_at, updated_at`,
+                 share_transport, share_contact, visibility, notes,
+                 traveling_with_guest_ids, created_at, updated_at`,
       [
         weddingId, guestId, data.plan_type,
         data.origin_city || null, data.origin_lat ?? null, data.origin_lng ?? null,
@@ -94,6 +120,7 @@ export async function PUT(
         data.share_contact ? sanitizeText(data.share_contact) : null,
         data.visibility,
         data.notes ? sanitizeText(data.notes) : null,
+        validCompanionIds.length > 0 ? validCompanionIds : null,
       ]
     );
 
@@ -130,6 +157,54 @@ export async function PUT(
         arrive_date: toDateString(saved.arrive_date),
         depart_date: toDateString(saved.depart_date),
       });
+    }
+
+    // Autofill companion travel plans. Each companion's traveling_with points to
+    // the primary guest plus any other companions, so the group is symmetric.
+    for (const companionId of validCompanionIds) {
+      const companionTravelingWith = [guestId, ...validCompanionIds.filter((id) => id !== companionId)];
+      const companionPlan = await pool.query(
+        `INSERT INTO travel_plans (wedding_id, guest_id, plan_type, origin_city, origin_lat, origin_lng,
+           origin_country, share_transport, share_contact, visibility, notes, traveling_with_guest_ids)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, false, null, $8, null, $9)
+         ON CONFLICT (wedding_id, guest_id) DO UPDATE SET
+           plan_type = EXCLUDED.plan_type,
+           origin_city = EXCLUDED.origin_city,
+           origin_lat = EXCLUDED.origin_lat,
+           origin_lng = EXCLUDED.origin_lng,
+           origin_country = EXCLUDED.origin_country,
+           visibility = EXCLUDED.visibility,
+           traveling_with_guest_ids = EXCLUDED.traveling_with_guest_ids,
+           updated_at = NOW()
+         RETURNING id`,
+        [
+          weddingId, companionId, data.plan_type,
+          data.origin_city || null, data.origin_lat ?? null, data.origin_lng ?? null,
+          data.origin_country || null, data.visibility, companionTravelingWith,
+        ]
+      );
+
+      const companionPlanId = companionPlan.rows[0].id;
+      await pool.query('DELETE FROM travel_stops WHERE plan_id = $1', [companionPlanId]);
+
+      for (let i = 0; i < data.stops.length; i++) {
+        const stop = data.stops[i];
+        await pool.query(
+          `INSERT INTO travel_stops (plan_id, wedding_id, stop_type, city, region, country,
+             country_code, latitude, longitude, arrive_date, depart_date, arrive_time, depart_time,
+             transport_mode, transport_details, accommodation, open_to_meetup, notes, sort_order)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)`,
+          [
+            companionPlanId, weddingId, stop.stop_type, stop.city, stop.region || null,
+            stop.country, stop.country_code || null, stop.latitude, stop.longitude,
+            stop.arrive_date || null, stop.depart_date || null, stop.arrive_time || null,
+            stop.depart_time || null,
+            stop.transport_mode || null, stop.transport_details || null,
+            stop.accommodation || null, stop.open_to_meetup,
+            stop.notes ? sanitizeText(stop.notes) : null, i,
+          ]
+        );
+      }
     }
 
     return Response.json({

--- a/components/travel/ArrivalsView.tsx
+++ b/components/travel/ArrivalsView.tsx
@@ -2,6 +2,11 @@
 
 import { useEffect, useState } from 'react';
 
+interface Companion {
+  id: string;
+  display_name: string;
+}
+
 interface ArrivalInfo {
   guest_id: string;
   display_name: string;
@@ -14,6 +19,7 @@ interface ArrivalInfo {
   transport_details: string | null;
   share_transport: boolean;
   origin_city: string | null;
+  traveling_with: Companion[];
 }
 
 const transportIcon: Record<string, string> = {
@@ -63,8 +69,29 @@ export default function ArrivalsView({ slug }: { slug: string }) {
     );
   }
 
-  const arrivingGuests = arrivals.filter((a) => a.stop_type === 'arrival');
-  const departingGuests = arrivals.filter((a) => a.stop_type === 'departure');
+  // Dedup by travel group: if a guest and their companions all appear with the same
+  // stop_type + date, only render one card for the group.
+  function dedupByGroup(list: ArrivalInfo[], dateField: 'arrive_date' | 'depart_date') {
+    const seen = new Set<string>();
+    const result: ArrivalInfo[] = [];
+    for (const a of list) {
+      const groupIds = [a.guest_id, ...a.traveling_with.map((c) => c.id)].sort();
+      const key = `${a.stop_type}|${a[dateField] || ''}|${groupIds.join(',')}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      result.push(a);
+    }
+    return result;
+  }
+
+  const arrivingGuests = dedupByGroup(
+    arrivals.filter((a) => a.stop_type === 'arrival'),
+    'arrive_date'
+  );
+  const departingGuests = dedupByGroup(
+    arrivals.filter((a) => a.stop_type === 'departure'),
+    'depart_date'
+  );
 
   // Group by date
   function groupByDate(list: ArrivalInfo[], dateField: 'arrive_date' | 'depart_date') {
@@ -154,51 +181,95 @@ export default function ArrivalsView({ slug }: { slug: string }) {
                   {date !== 'Unknown' ? formatDateLabel(date) : 'Date TBD'}
                 </p>
                 <div className="space-y-2">
-                  {dateGuests.map((guest) => (
-                    <div
-                      key={guest.guest_id}
-                      className="flex items-center gap-3 p-3.5 rounded-2xl"
-                      style={{
-                        background: 'var(--bg-pure-white)',
-                        border: '1px solid var(--border-light)',
-                        boxShadow: '0 1px 4px rgba(0,0,0,0.02)',
-                      }}
-                    >
+                  {dateGuests.map((guest) => {
+                    const hasCompanions = guest.traveling_with && guest.traveling_with.length > 0;
+                    return (
                       <div
-                        className="w-10 h-10 rounded-full flex items-center justify-center text-sm font-semibold flex-shrink-0"
+                        key={guest.guest_id}
+                        className="flex items-center gap-3 p-3.5 rounded-2xl relative"
                         style={{
-                          background: avatarBg,
-                          color: '#FDFBF7',
-                          boxShadow: '0 2px 6px rgba(0,0,0,0.1)',
+                          background: hasCompanions
+                            ? 'linear-gradient(135deg, rgba(198,163,85,0.06) 0%, var(--bg-pure-white) 60%)'
+                            : 'var(--bg-pure-white)',
+                          border: hasCompanions
+                            ? '1px solid rgba(198,163,85,0.25)'
+                            : '1px solid var(--border-light)',
+                          boxShadow: '0 1px 4px rgba(0,0,0,0.02)',
                         }}
                       >
-                        {guest.display_name.charAt(0)}
+                        {hasCompanions ? (
+                          <div className="relative flex-shrink-0" style={{ width: 44, height: 40 }}>
+                            <div
+                              className="absolute w-9 h-9 rounded-full flex items-center justify-center text-sm font-semibold"
+                              style={{
+                                top: 0,
+                                left: 0,
+                                background: avatarBg,
+                                color: '#FDFBF7',
+                                boxShadow: '0 2px 6px rgba(0,0,0,0.1)',
+                                zIndex: 2,
+                              }}
+                            >
+                              {guest.display_name.charAt(0)}
+                            </div>
+                            <div
+                              className="absolute w-7 h-7 rounded-full flex items-center justify-center text-xs font-semibold"
+                              style={{
+                                bottom: -2,
+                                right: -2,
+                                background: 'linear-gradient(145deg, var(--color-gold-dark), var(--color-gold))',
+                                color: '#FDFBF7',
+                                border: '2px solid var(--bg-pure-white)',
+                                zIndex: 1,
+                              }}
+                            >
+                              {guest.traveling_with[0].display_name.charAt(0)}
+                            </div>
+                          </div>
+                        ) : (
+                          <div
+                            className="w-10 h-10 rounded-full flex items-center justify-center text-sm font-semibold flex-shrink-0"
+                            style={{
+                              background: avatarBg,
+                              color: '#FDFBF7',
+                              boxShadow: '0 2px 6px rgba(0,0,0,0.1)',
+                            }}
+                          >
+                            {guest.display_name.charAt(0)}
+                          </div>
+                        )}
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
+                            {guest.display_name}
+                            {hasCompanions && (
+                              <span className="font-normal" style={{ color: 'var(--text-secondary)' }}>
+                                {' '}&amp;{' '}
+                                {guest.traveling_with.map((c) => c.display_name.split(' ')[0]).join(' & ')}
+                              </span>
+                            )}
+                          </p>
+                          <p className="text-xs mt-0.5" style={{ color: 'var(--text-secondary)' }}>
+                            {dateField === 'arrive_date' && guest.arrive_time ? formatTime(guest.arrive_time) : ''}
+                            {dateField === 'depart_date' && guest.depart_time ? formatTime(guest.depart_time) : ''}
+                            {guest.transport_mode && ` ${transportIcon[guest.transport_mode]}`}
+                            {guest.transport_details && ` ${guest.transport_details}`}
+                            {guest.origin_city ? ` from ${guest.origin_city}` : ''}
+                          </p>
+                        </div>
+                        {guest.share_transport && (
+                          <span
+                            className="text-[11px] font-medium px-2.5 py-1 rounded-full flex-shrink-0"
+                            style={{
+                              background: 'rgba(198,163,85,0.1)',
+                              color: 'var(--color-gold-dark)',
+                            }}
+                          >
+                            Sharing
+                          </span>
+                        )}
                       </div>
-                      <div className="flex-1 min-w-0">
-                        <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
-                          {guest.display_name}
-                        </p>
-                        <p className="text-xs mt-0.5" style={{ color: 'var(--text-secondary)' }}>
-                          {dateField === 'arrive_date' && guest.arrive_time ? formatTime(guest.arrive_time) : ''}
-                          {dateField === 'depart_date' && guest.depart_time ? formatTime(guest.depart_time) : ''}
-                          {guest.transport_mode && ` ${transportIcon[guest.transport_mode]}`}
-                          {guest.transport_details && ` ${guest.transport_details}`}
-                          {guest.origin_city ? ` from ${guest.origin_city}` : ''}
-                        </p>
-                      </div>
-                      {guest.share_transport && (
-                        <span
-                          className="text-[11px] font-medium px-2.5 py-1 rounded-full flex-shrink-0"
-                          style={{
-                            background: 'rgba(198,163,85,0.1)',
-                            color: 'var(--color-gold-dark)',
-                          }}
-                        >
-                          Sharing
-                        </span>
-                      )}
-                    </div>
-                  ))}
+                    );
+                  })}
                 </div>
               </div>
             ))}

--- a/components/travel/TravelPlanForm.tsx
+++ b/components/travel/TravelPlanForm.tsx
@@ -71,6 +71,12 @@ interface ValidationIssue {
   message: string;
 }
 
+interface Companion {
+  id: string;
+  first_name: string;
+  last_name: string;
+}
+
 export default function TravelPlanForm({ slug, onSaved, venueCity, venueCountry }: TravelPlanFormProps) {
   const [planType, setPlanType] = useState<PlanType | null>(null);
   const [originCity, setOriginCity] = useState('');
@@ -85,6 +91,13 @@ export default function TravelPlanForm({ slug, onSaved, venueCity, venueCountry 
   const [error, setError] = useState<string | null>(null);
   const [existingPlan, setExistingPlan] = useState(false);
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+
+  // Traveling-with companions
+  const [currentGuestId, setCurrentGuestId] = useState<string | null>(null);
+  const [companions, setCompanions] = useState<Companion[]>([]);
+  const [companionSearch, setCompanionSearch] = useState('');
+  const [companionResults, setCompanionResults] = useState<Companion[]>([]);
+  const [companionSearchFocused, setCompanionSearchFocused] = useState(false);
 
   // Wedding venue coordinates (looked up on mount)
   const [venueLat, setVenueLat] = useState(0);
@@ -127,10 +140,22 @@ export default function TravelPlanForm({ slug, onSaved, venueCity, venueCountry 
     fetch(`/api/v1/w/${slug}/travel/my-plan`)
       .then((res) => res.json())
       .then((data) => {
+        if (data.data?.guest_id) setCurrentGuestId(data.data.guest_id);
         const plan = data.data?.plan;
         if (!plan) return;
 
         setExistingPlan(true);
+
+        // Load traveling-with companions
+        if (plan.traveling_with?.length > 0) {
+          setCompanions(
+            plan.traveling_with.map((g: { id: string; first_name: string; last_name: string }) => ({
+              id: g.id,
+              first_name: g.first_name,
+              last_name: g.last_name,
+            }))
+          );
+        }
         setPlanType(plan.plan_type);
         setOriginCity(plan.origin_city || '');
         setOriginCountry(plan.origin_country || '');
@@ -198,6 +223,39 @@ export default function TravelPlanForm({ slug, onSaved, venueCity, venueCountry 
       })
       .catch(console.error);
   }, [slug]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Debounced companion search
+  useEffect(() => {
+    if (companionSearch.trim().length < 2) {
+      setCompanionResults([]);
+      return;
+    }
+    const timeout = setTimeout(() => {
+      fetch(`/api/v1/w/${slug}/guests/search?q=${encodeURIComponent(companionSearch.trim())}`)
+        .then((res) => res.json())
+        .then((data) => {
+          const guests: Companion[] = data.data?.guests || [];
+          const selectedIds = new Set(companions.map((c) => c.id));
+          setCompanionResults(
+            guests.filter(
+              (g) => g.id !== currentGuestId && !selectedIds.has(g.id)
+            )
+          );
+        })
+        .catch(console.error);
+    }, 250);
+    return () => clearTimeout(timeout);
+  }, [companionSearch, slug, companions, currentGuestId]);
+
+  function addCompanion(guest: Companion) {
+    setCompanions((prev) => [...prev, guest]);
+    setCompanionSearch('');
+    setCompanionResults([]);
+  }
+
+  function removeCompanion(guestId: string) {
+    setCompanions((prev) => prev.filter((c) => c.id !== guestId));
+  }
 
   const weddingLegIndex = useMemo(() => legs.findIndex((l) => l.isWedding), [legs]);
 
@@ -375,6 +433,7 @@ export default function TravelPlanForm({ slug, onSaved, venueCity, venueCountry 
           share_contact: shareTransport ? shareContact : undefined,
           visibility,
           notes: planNotes || undefined,
+          traveling_with_guest_ids: companions.length > 0 ? companions.map((c) => c.id) : undefined,
           stops,
         }),
       });
@@ -404,6 +463,7 @@ export default function TravelPlanForm({ slug, onSaved, venueCity, venueCountry 
       setOriginLng(0);
       setShareContact('');
       setLegs([createWeddingLeg(venueCity || '', venueCountry || '', venueLat, venueLng)]);
+      setCompanions([]);
       setExistingPlan(false);
     } catch {
       setError('Failed to delete');
@@ -718,6 +778,110 @@ export default function TravelPlanForm({ slug, onSaved, venueCity, venueCountry 
               >
                 + Add a stop after the wedding
               </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Traveling with */}
+      <div
+        className="rounded-2xl p-4"
+        style={{
+          background: 'linear-gradient(145deg, rgba(198,163,85,0.08) 0%, rgba(196,112,75,0.05) 100%)',
+          border: '1px solid rgba(198,163,85,0.18)',
+        }}
+      >
+        <div className="flex items-center gap-2 mb-1">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--color-gold-dark)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2" />
+            <circle cx="9" cy="7" r="4" />
+            <path d="M23 21v-2a4 4 0 00-3-3.87" />
+            <path d="M16 3.13a4 4 0 010 7.75" />
+          </svg>
+          <label className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
+            Traveling with
+          </label>
+        </div>
+        <p className="text-xs mb-3" style={{ color: 'var(--text-secondary)' }}>
+          Add partners or friends you&rsquo;re traveling with &mdash; we&rsquo;ll mirror your plan to theirs
+        </p>
+
+        {/* Selected companions */}
+        {companions.length > 0 && (
+          <div className="flex flex-wrap gap-2 mb-3">
+            {companions.map((c) => (
+              <span
+                key={c.id}
+                className="inline-flex items-center gap-1.5 pl-3 pr-1 py-1 rounded-full text-sm"
+                style={{
+                  background: 'linear-gradient(135deg, var(--color-gold-dark), var(--color-gold))',
+                  color: '#FDFBF7',
+                  boxShadow: '0 2px 6px rgba(198,163,85,0.25)',
+                }}
+              >
+                {c.first_name} {c.last_name}
+                <button
+                  type="button"
+                  onClick={() => removeCompanion(c.id)}
+                  className="w-5 h-5 rounded-full flex items-center justify-center text-xs"
+                  style={{ background: 'rgba(255,255,255,0.25)', color: '#FDFBF7' }}
+                  aria-label={`Remove ${c.first_name}`}
+                >
+                  &times;
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* Search */}
+        <div className="relative">
+          <input
+            type="text"
+            value={companionSearch}
+            onChange={(e) => setCompanionSearch(e.target.value)}
+            onFocus={() => setCompanionSearchFocused(true)}
+            onBlur={() => setTimeout(() => setCompanionSearchFocused(false), 150)}
+            placeholder={companions.length > 0 ? 'Add another guest...' : 'Search guests by name...'}
+            className="w-full px-3 py-2 rounded-lg text-sm border"
+            style={{
+              borderColor: 'var(--border-light)',
+              color: 'var(--text-primary)',
+              background: 'var(--bg-pure-white)',
+            }}
+          />
+          {companionSearchFocused && companionResults.length > 0 && (
+            <div
+              className="absolute z-20 left-0 right-0 mt-1 rounded-xl overflow-hidden"
+              style={{
+                background: 'var(--bg-pure-white)',
+                border: '1px solid var(--border-light)',
+                boxShadow: '0 8px 24px rgba(0,0,0,0.08)',
+                maxHeight: 240,
+                overflowY: 'auto',
+              }}
+            >
+              {companionResults.map((g) => (
+                <button
+                  key={g.id}
+                  type="button"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => addCompanion(g)}
+                  className="w-full px-4 py-2.5 text-left text-sm flex items-center gap-3 transition-colors hover:bg-[var(--bg-warm-white)]"
+                  style={{ color: 'var(--text-primary)' }}
+                >
+                  <div
+                    className="w-7 h-7 rounded-full flex items-center justify-center text-xs font-semibold flex-shrink-0"
+                    style={{
+                      background: 'linear-gradient(145deg, rgba(198,163,85,0.15), rgba(198,163,85,0.08))',
+                      color: 'var(--color-gold-dark)',
+                    }}
+                  >
+                    {g.first_name.charAt(0)}
+                  </div>
+                  {g.first_name} {g.last_name}
+                </button>
+              ))}
             </div>
           )}
         </div>

--- a/lib/db/migrations/016_traveling_with.sql
+++ b/lib/db/migrations/016_traveling_with.sql
@@ -1,0 +1,3 @@
+-- 016_traveling_with.sql
+-- Add traveling_with field to link companions' travel plans
+ALTER TABLE travel_plans ADD COLUMN traveling_with_guest_ids UUID[];

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -65,6 +65,7 @@ export const travelPlanSchema = z.object({
   share_contact: z.string().max(200).optional(),
   visibility: z.enum(['full', 'city_only', 'private']).default('full'),
   notes: z.string().max(500).optional(),
+  traveling_with_guest_ids: z.array(z.string().uuid()).max(10).optional(),
   stops: z.array(travelStopInputSchema).min(1).max(20),
 }).refine(
   (d) => !d.share_transport || (d.share_contact && d.share_contact.trim().length > 0),


### PR DESCRIPTION
Guests can now select companions from the guest list when filling out their travel plan. Their travel data is mirrored to each companion's plan automatically, so couples only need one person to set it up.

The arrivals view now shows grouped cards with paired avatars for guests traveling together.

https://claude.ai/code/session_01A3JYPt5VgMUGZqzfzo28qB