### PR TITLE
Add custom audience selection for email guests

### DIFF
--- a/app/dashboard/[weddingId]/emails/page.tsx
+++ b/app/dashboard/[weddingId]/emails/page.tsx
@@ -2,7 +2,16 @@
 
 import { useState, useEffect, use } from 'react';
 
-type Audience = 'all' | 'attending' | 'pending' | 'declined';
+type Audience = 'all' | 'attending' | 'pending' | 'declined' | 'custom';
+
+interface GuestPickerItem {
+  id: string;
+  first_name: string;
+  last_name: string;
+  email: string | null;
+  rsvp_status: 'pending' | 'attending' | 'declined';
+  group_label: string | null;
+}
 
 interface EmailStatus {
   configured: boolean;
@@ -85,6 +94,13 @@ export default function EmailsPage({ params }: { params: Promise<{ weddingId: st
   const [sendError, setSendError] = useState('');
   const [confirmOpen, setConfirmOpen] = useState(false);
 
+  // Custom audience state
+  const [selectedGuestIds, setSelectedGuestIds] = useState<Set<string>>(new Set());
+  const [guestPickerOpen, setGuestPickerOpen] = useState(false);
+  const [guestList, setGuestList] = useState<GuestPickerItem[]>([]);
+  const [guestListLoading, setGuestListLoading] = useState(false);
+  const [guestSearch, setGuestSearch] = useState('');
+
   useEffect(() => {
     fetch(`/api/v1/dashboard/weddings/${weddingId}/emails/status`)
       .then((res) => res.json())
@@ -102,12 +118,65 @@ export default function EmailsPage({ params }: { params: Promise<{ weddingId: st
     setCtaLabel(t.cta_label || '');
   };
 
+  // Fetch guest list the first time the picker is opened
+  const openGuestPicker = async () => {
+    setGuestPickerOpen(true);
+    if (guestList.length > 0) return;
+    setGuestListLoading(true);
+    try {
+      const res = await fetch(`/api/v1/dashboard/weddings/${weddingId}/guests`);
+      const data = await res.json();
+      const withEmail: GuestPickerItem[] = (data.guests || []).filter(
+        (g: GuestPickerItem) => g.email && g.email.trim().length > 0
+      );
+      setGuestList(withEmail);
+    } catch {
+      // silent; user can retry by reopening
+    } finally {
+      setGuestListLoading(false);
+    }
+  };
+
+  const toggleGuestSelected = (id: string) => {
+    setSelectedGuestIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const filteredGuestList = guestList.filter((g) => {
+    if (!guestSearch.trim()) return true;
+    const q = guestSearch.toLowerCase();
+    const name = `${g.first_name} ${g.last_name}`.toLowerCase();
+    return name.includes(q) || (g.email || '').toLowerCase().includes(q);
+  });
+
+  const allFilteredSelected =
+    filteredGuestList.length > 0 &&
+    filteredGuestList.every((g) => selectedGuestIds.has(g.id));
+
+  const toggleSelectAllFiltered = () => {
+    setSelectedGuestIds((prev) => {
+      const next = new Set(prev);
+      if (allFilteredSelected) {
+        for (const g of filteredGuestList) next.delete(g.id);
+      } else {
+        for (const g of filteredGuestList) next.add(g.id);
+      }
+      return next;
+    });
+  };
+
   const audienceCount =
-    status?.counts[
-      audience === 'all'
-        ? 'with_email'
-        : (audience as 'attending' | 'pending' | 'declined')
-    ] ?? 0;
+    audience === 'custom'
+      ? selectedGuestIds.size
+      : status?.counts[
+          audience === 'all'
+            ? 'with_email'
+            : (audience as 'attending' | 'pending' | 'declined')
+        ] ?? 0;
 
   const canSend =
     !!status?.configured &&
@@ -131,7 +200,8 @@ export default function EmailsPage({ params }: { params: Promise<{ weddingId: st
           body: body.trim(),
           cta_label: ctaLabel.trim() || undefined,
           cta_url: ctaUrl.trim() || undefined,
-          audience,
+          audience: audience === 'custom' ? 'selected' : audience,
+          guest_ids: audience === 'custom' ? Array.from(selectedGuestIds) : undefined,
           reply_to: replyTo.trim() || undefined,
         }),
       });
@@ -317,12 +387,17 @@ RESEND_REPLY_TO=shriyaneilwedding@gmail.com`}
               { id: 'attending', label: 'Attending', count: status?.counts.attending ?? 0 },
               { id: 'pending', label: 'Pending', count: status?.counts.pending ?? 0 },
               { id: 'declined', label: 'Declined', count: status?.counts.declined ?? 0 },
+              { id: 'custom', label: 'Custom', count: selectedGuestIds.size },
             ] as const).map((opt) => {
               const active = audience === opt.id;
+              const isCustom = opt.id === 'custom';
               return (
                 <button
                   key={opt.id}
-                  onClick={() => setAudience(opt.id)}
+                  onClick={() => {
+                    setAudience(opt.id);
+                    if (isCustom) openGuestPicker();
+                  }}
                   style={{
                     padding: '10px 16px',
                     borderRadius: 12,
@@ -349,13 +424,31 @@ RESEND_REPLY_TO=shriyaneilwedding@gmail.com`}
                       fontWeight: 600,
                     }}
                   >
-                    {opt.count}
+                    {isCustom && opt.count === 0 ? 'pick' : opt.count}
                   </span>
                 </button>
               );
             })}
           </div>
-          {status && status.counts.total > status.counts.with_email && (
+          {audience === 'custom' && selectedGuestIds.size > 0 && (
+            <button
+              onClick={openGuestPicker}
+              style={{
+                marginTop: 10,
+                padding: '6px 12px',
+                borderRadius: 8,
+                border: '1px solid var(--border-light)',
+                background: 'var(--bg-pure-white)',
+                color: 'var(--color-gold-dark)',
+                fontSize: 12,
+                fontFamily: 'var(--font-body)',
+                cursor: 'pointer',
+              }}
+            >
+              Edit selection ({selectedGuestIds.size} guest{selectedGuestIds.size === 1 ? '' : 's'})
+            </button>
+          )}
+          {audience !== 'custom' && status && status.counts.total > status.counts.with_email && (
             <p style={{ margin: '10px 0 0', fontSize: 12, color: 'var(--text-tertiary)', fontFamily: 'var(--font-body)' }}>
               {status.counts.total - status.counts.with_email} guest{status.counts.total - status.counts.with_email === 1 ? ' has' : 's have'} no email on file and will be skipped.
             </p>
@@ -518,6 +611,192 @@ RESEND_REPLY_TO=shriyaneilwedding@gmail.com`}
         </div>
       )}
 
+      {/* Guest picker modal */}
+      {guestPickerOpen && (
+        <div
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(27, 28, 26, 0.4)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 100,
+            padding: 20,
+          }}
+          onClick={() => setGuestPickerOpen(false)}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              background: 'var(--bg-pure-white)',
+              borderRadius: 16,
+              maxWidth: 560,
+              width: '100%',
+              maxHeight: '80vh',
+              display: 'flex',
+              flexDirection: 'column',
+              boxShadow: '0 20px 50px rgba(0,0,0,0.15)',
+              overflow: 'hidden',
+            }}
+          >
+            <div style={{ padding: '22px 24px 14px', borderBottom: '1px solid var(--border-light)' }}>
+              <h3 style={{ fontFamily: 'var(--font-display)', fontSize: 22, fontWeight: 500, margin: '0 0 6px', color: 'var(--text-primary)' }}>
+                Pick guests to email
+              </h3>
+              <p style={{ fontSize: 13, color: 'var(--text-secondary)', margin: 0, fontFamily: 'var(--font-body)' }}>
+                Only guests with an email on file are shown.
+              </p>
+              <input
+                type="text"
+                value={guestSearch}
+                onChange={(e) => setGuestSearch(e.target.value)}
+                placeholder="Search by name or email..."
+                style={{
+                  ...inputStyle,
+                  marginTop: 14,
+                }}
+                autoFocus
+              />
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 12 }}>
+                <span style={{ fontSize: 12, color: 'var(--text-tertiary)', fontFamily: 'var(--font-body)' }}>
+                  {selectedGuestIds.size} of {guestList.length} selected
+                </span>
+                {filteredGuestList.length > 0 && (
+                  <button
+                    onClick={toggleSelectAllFiltered}
+                    style={{
+                      padding: '4px 10px',
+                      borderRadius: 8,
+                      border: 'none',
+                      background: 'transparent',
+                      color: 'var(--color-gold-dark)',
+                      fontSize: 12,
+                      fontFamily: 'var(--font-body)',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    {allFilteredSelected ? 'Clear' : 'Select all'}
+                    {guestSearch.trim() ? ' matching' : ''}
+                  </button>
+                )}
+              </div>
+            </div>
+
+            <div style={{ overflowY: 'auto', flex: 1, padding: '8px 8px' }}>
+              {guestListLoading ? (
+                <div style={{ padding: 32, textAlign: 'center', fontSize: 13, color: 'var(--text-tertiary)', fontFamily: 'var(--font-body)' }}>
+                  Loading guests...
+                </div>
+              ) : filteredGuestList.length === 0 ? (
+                <div style={{ padding: 32, textAlign: 'center', fontSize: 13, color: 'var(--text-tertiary)', fontFamily: 'var(--font-body)' }}>
+                  {guestList.length === 0
+                    ? 'No guests with an email on file yet.'
+                    : `No guests match "${guestSearch}"`}
+                </div>
+              ) : (
+                filteredGuestList.map((g) => {
+                  const selected = selectedGuestIds.has(g.id);
+                  return (
+                    <label
+                      key={g.id}
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 12,
+                        padding: '10px 14px',
+                        borderRadius: 10,
+                        cursor: 'pointer',
+                        background: selected ? 'rgba(198,163,85,0.06)' : 'transparent',
+                        transition: 'background 0.1s',
+                      }}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selected}
+                        onChange={() => toggleGuestSelected(g.id)}
+                        style={{ width: 16, height: 16, accentColor: 'var(--color-gold-dark)', cursor: 'pointer' }}
+                      />
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <p style={{ margin: 0, fontSize: 14, color: 'var(--text-primary)', fontFamily: 'var(--font-body)', fontWeight: 500 }}>
+                          {g.first_name} {g.last_name}
+                        </p>
+                        <p style={{ margin: '2px 0 0', fontSize: 12, color: 'var(--text-tertiary)', fontFamily: 'var(--font-body)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          {g.email}
+                          {g.group_label && ` · ${g.group_label}`}
+                        </p>
+                      </div>
+                      <span
+                        style={{
+                          fontSize: 10,
+                          textTransform: 'uppercase',
+                          letterSpacing: '0.4px',
+                          padding: '3px 8px',
+                          borderRadius: 999,
+                          fontWeight: 600,
+                          background:
+                            g.rsvp_status === 'attending'
+                              ? 'rgba(122,139,92,0.12)'
+                              : g.rsvp_status === 'declined'
+                              ? 'rgba(196,112,75,0.1)'
+                              : 'var(--bg-soft-cream)',
+                          color:
+                            g.rsvp_status === 'attending'
+                              ? 'var(--color-olive)'
+                              : g.rsvp_status === 'declined'
+                              ? 'var(--color-terracotta)'
+                              : 'var(--text-tertiary)',
+                        }}
+                      >
+                        {g.rsvp_status}
+                      </span>
+                    </label>
+                  );
+                })
+              )}
+            </div>
+
+            <div style={{ display: 'flex', gap: 10, justifyContent: 'space-between', padding: '16px 24px', borderTop: '1px solid var(--border-light)' }}>
+              <button
+                onClick={() => {
+                  setSelectedGuestIds(new Set());
+                }}
+                disabled={selectedGuestIds.size === 0}
+                style={{
+                  padding: '10px 16px',
+                  borderRadius: 10,
+                  border: 'none',
+                  background: 'transparent',
+                  color: selectedGuestIds.size === 0 ? 'var(--text-tertiary)' : 'var(--text-secondary)',
+                  fontSize: 13,
+                  fontFamily: 'var(--font-body)',
+                  cursor: selectedGuestIds.size === 0 ? 'default' : 'pointer',
+                }}
+              >
+                Clear all
+              </button>
+              <button
+                onClick={() => setGuestPickerOpen(false)}
+                style={{
+                  padding: '10px 24px',
+                  borderRadius: 10,
+                  border: 'none',
+                  background: 'linear-gradient(135deg, var(--color-gold-dark), var(--color-gold))',
+                  color: '#FDFBF7',
+                  fontSize: 14,
+                  fontWeight: 500,
+                  fontFamily: 'var(--font-body)',
+                  cursor: 'pointer',
+                  boxShadow: '0 2px 8px rgba(198,163,85,0.25)',
+                }}
+              >
+                Done
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Confirm modal */}
       {confirmOpen && (
         <div
@@ -548,9 +827,19 @@ RESEND_REPLY_TO=shriyaneilwedding@gmail.com`}
               Send to {audienceCount} guest{audienceCount === 1 ? '' : 's'}?
             </h3>
             <p style={{ fontSize: 14, color: 'var(--text-secondary)', margin: '0 0 20px', fontFamily: 'var(--font-body)', lineHeight: 1.55 }}>
-              This will send &ldquo;{subject}&rdquo; to everyone in the{' '}
-              <strong style={{ color: 'var(--text-primary)' }}>{audience}</strong> audience with an email on file.
-              This cannot be undone.
+              {audience === 'custom' ? (
+                <>
+                  This will send &ldquo;{subject}&rdquo; to your{' '}
+                  <strong style={{ color: 'var(--text-primary)' }}>{selectedGuestIds.size} selected</strong>{' '}
+                  guest{selectedGuestIds.size === 1 ? '' : 's'}. This cannot be undone.
+                </>
+              ) : (
+                <>
+                  This will send &ldquo;{subject}&rdquo; to everyone in the{' '}
+                  <strong style={{ color: 'var(--text-primary)' }}>{audience}</strong> audience with an email on file.
+                  This cannot be undone.
+                </>
+              )}
             </p>
             <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end' }}>
               <button


### PR DESCRIPTION
Clicking the new Custom pill opens a searchable guest picker showing only guests with emails on file. Each row has a checkbox plus RSVP badge so couples can cherry-pick recipients without filtering by status. The selection count drives the send button and confirmation copy, and Edit selection lets couples revise without losing state.

https://claude.ai/code/session_01A3JYPt5VgMUGZqzfzo28qB