### PR TITLE
Fix video recording producing empty blob, un-mirror front camera

### DIFF
--- a/app/w/[slug]/video/page.tsx
+++ b/app/w/[slug]/video/page.tsx
@@ -103,10 +103,13 @@ export default function VideoRecordingPage() {
   }, [facingMode]);
 
   useEffect(() => {
-    if ((phase === 'viewfinder' || phase === 'recording') && !isLoading && isAuthenticated) {
+    if (phase === 'viewfinder' && !isLoading && isAuthenticated) {
       startCamera();
     }
+  }, [phase, isLoading, isAuthenticated, facingMode, startCamera]);
 
+  // Cleanup only on unmount
+  useEffect(() => {
     return () => {
       if (streamRef.current) {
         streamRef.current.getTracks().forEach((t) => t.stop());
@@ -115,8 +118,7 @@ export default function VideoRecordingPage() {
         clearInterval(timerRef.current);
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [phase === 'viewfinder', isLoading, isAuthenticated, facingMode]);
+  }, []);
 
   useEffect(() => {
     return () => {
@@ -385,7 +387,10 @@ export default function VideoRecordingPage() {
               playsInline
               muted
               className="absolute inset-0 w-full h-full"
-              style={{ objectFit: 'cover' }}
+              style={{
+                objectFit: 'cover',
+                transform: facingMode === 'user' ? 'scaleX(-1)' : undefined,
+              }}
             />
             {/* Gradient overlay */}
             <div


### PR DESCRIPTION
The camera useEffect cleanup was killing the MediaStream the instant phase changed from viewfinder to recording, so the MediaRecorder lost its source and immediately fired onstop with zero data. Split into two effects: one that starts the camera only on viewfinder entry, and a separate unmount-only cleanup, so the stream stays alive throughout recording.

Also counter the native front-camera mirror by applying scaleX(-1) to the preview video when facingMode is 'user'.

https://claude.ai/code/session_01A3JYPt5VgMUGZqzfzo28qB