### PR TITLE
Fix video upload AUTH_TOKEN_EXPIRED by auto-refreshing stale sessions

### DIFF
--- a/app/w/[slug]/video/page.tsx
+++ b/app/w/[slug]/video/page.tsx
@@ -231,6 +231,20 @@ export default function VideoRecordingPage() {
     setPhase('viewfinder');
   };
 
+  const refreshSession = async (): Promise<boolean> => {
+    if (!guest) return false;
+    try {
+      const res = await fetch(`/api/v1/w/${slug}/auth/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ guest_id: guest.id }),
+      });
+      return res.ok;
+    } catch {
+      return false;
+    }
+  };
+
   const uploadVideo = async () => {
     if (!recordedBlob || !guest) return;
 
@@ -240,7 +254,7 @@ export default function VideoRecordingPage() {
     const mimeType = recordedBlob.type.includes('mp4') ? 'video/mp4' : 'video/webm';
 
     try {
-      const presignRes = await fetch(`/api/v1/w/${slug}/upload/presign`, {
+      let presignRes = await fetch(`/api/v1/w/${slug}/upload/presign`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -249,6 +263,21 @@ export default function VideoRecordingPage() {
           size_bytes: recordedBlob.size,
         }),
       });
+
+      if (presignRes.status === 401) {
+        const refreshed = await refreshSession();
+        if (refreshed) {
+          presignRes = await fetch(`/api/v1/w/${slug}/upload/presign`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              type: 'video',
+              mime_type: mimeType,
+              size_bytes: recordedBlob.size,
+            }),
+          });
+        }
+      }
 
       if (!presignRes.ok) {
         throw new Error('Failed to get upload URL');


### PR DESCRIPTION
When the presign endpoint returns 401, silently re-register the guest session using the guest ID from context, then retry the presign call. This handles cases where the server-side session was invalidated (DB reset, secret rotation) while the client still has valid localStorage state.

https://claude.ai/code/session_01A3JYPt5VgMUGZqzfzo28qB