### PR TITLE
Fix video thumbnails and filter videos out of portraits tab

### DIFF
--- a/app/api/v1/w/[slug]/media/[guestId]/route.ts
+++ b/app/api/v1/w/[slug]/media/[guestId]/route.ts
@@ -42,50 +42,67 @@ export async function GET(
     const cursor = url.searchParams.get('cursor');
     const limit = Math.min(parseInt(url.searchParams.get('limit') || '20', 10), 100);
 
-    // Build query for uploads
-    const conditions: string[] = ['u.wedding_id = $1', 'u.guest_id = $2', "u.status = 'ready'"];
-    const queryParams: (string | number)[] = [session.weddingId, guestId];
-    let paramIndex = 3;
+    // Uploads query only runs for all/photo/video/favorite tabs, not for 'portrait'
+    const skipUploads = typeFilter === 'portrait';
 
-    const isFavoriteFilter = typeFilter === 'favorite';
+    type UploadRow = {
+      id: string;
+      type: string;
+      storage_key: string;
+      thumbnail_key: string | null;
+      filter_applied: string | null;
+      duration_ms: number | null;
+      created_at: Date;
+      event_name: string | null;
+      favorited?: boolean;
+    };
+    let uploadsResult: { rows: UploadRow[] } = { rows: [] };
 
-    if (typeFilter && ['photo', 'video'].includes(typeFilter)) {
-      conditions.push(`u.type = $${paramIndex}`);
-      queryParams.push(typeFilter);
-      paramIndex++;
+    if (!skipUploads) {
+      const conditions: string[] = ['u.wedding_id = $1', 'u.guest_id = $2', "u.status = 'ready'"];
+      const queryParams: (string | number)[] = [session.weddingId, guestId];
+      let paramIndex = 3;
+
+      const isFavoriteFilter = typeFilter === 'favorite';
+
+      if (typeFilter && ['photo', 'video'].includes(typeFilter)) {
+        conditions.push(`u.type = $${paramIndex}`);
+        queryParams.push(typeFilter);
+        paramIndex++;
+      }
+
+      if (isFavoriteFilter) {
+        conditions.push(`EXISTS (SELECT 1 FROM favorites fav WHERE fav.upload_id = u.id AND fav.guest_id = u.guest_id)`);
+      }
+
+      if (eventId) {
+        conditions.push(`u.event_id = $${paramIndex}`);
+        queryParams.push(eventId);
+        paramIndex++;
+      }
+
+      if (cursor) {
+        conditions.push(`u.created_at < $${paramIndex}`);
+        queryParams.push(cursor);
+        paramIndex++;
+      }
+
+      queryParams.push(limit + 1);
+
+      const uploadsQuery = `
+        SELECT u.id, u.type, u.storage_key, u.thumbnail_key, u.filter_applied,
+               u.duration_ms, u.created_at, e.name as event_name,
+               CASE WHEN f.id IS NOT NULL THEN true ELSE false END as favorited
+        FROM uploads u
+        LEFT JOIN events e ON u.event_id = e.id
+        LEFT JOIN favorites f ON f.upload_id = u.id AND f.guest_id = u.guest_id
+        WHERE ${conditions.join(' AND ')}
+        ORDER BY u.created_at DESC
+        LIMIT $${paramIndex}
+      `;
+
+      uploadsResult = await pool.query(uploadsQuery, queryParams);
     }
-
-    if (isFavoriteFilter) {
-      conditions.push(`EXISTS (SELECT 1 FROM favorites fav WHERE fav.upload_id = u.id AND fav.guest_id = u.guest_id)`);
-    }
-
-    if (eventId) {
-      conditions.push(`u.event_id = $${paramIndex}`);
-      queryParams.push(eventId);
-      paramIndex++;
-    }
-
-    if (cursor) {
-      conditions.push(`u.created_at < $${paramIndex}`);
-      queryParams.push(cursor);
-      paramIndex++;
-    }
-
-    queryParams.push(limit + 1);
-
-    const uploadsQuery = `
-      SELECT u.id, u.type, u.storage_key, u.thumbnail_key, u.filter_applied,
-             u.duration_ms, u.created_at, e.name as event_name,
-             CASE WHEN f.id IS NOT NULL THEN true ELSE false END as favorited
-      FROM uploads u
-      LEFT JOIN events e ON u.event_id = e.id
-      LEFT JOIN favorites f ON f.upload_id = u.id AND f.guest_id = u.guest_id
-      WHERE ${conditions.join(' AND ')}
-      ORDER BY u.created_at DESC
-      LIMIT $${paramIndex}
-    `;
-
-    const uploadsResult = await pool.query(uploadsQuery, queryParams);
 
     // Also get AI portraits for this guest
     let portraits: typeof uploadsResult.rows = [];

--- a/app/api/v1/w/[slug]/upload/complete/route.ts
+++ b/app/api/v1/w/[slug]/upload/complete/route.ts
@@ -63,12 +63,12 @@ export async function POST(
       throw new AppError('VALIDATION_ERROR', 'Upload already completed');
     }
 
-    // Generate thumbnail key
-    const thumbnailKey = getThumbnailKey(storage_key);
-
-    // Generate and upload thumbnail for photos
+    // Generate thumbnail for photos only. Videos don't get a thumbnail file —
+    // the gallery renders a <video> element that shows the first frame.
     const isPhoto = !duration_ms; // videos have duration_ms
+    let thumbnailKey: string | null = null;
     if (isPhoto) {
+      thumbnailKey = getThumbnailKey(storage_key);
       try {
         const original = await getObject(storage_key);
         const thumbnailBuffer = await generateThumbnail(original);
@@ -108,7 +108,7 @@ export async function POST(
           id: updated.id,
           type: updated.type,
           url: await getMediaUrl(updated.storage_key),
-          thumbnail_url: await getMediaUrl(thumbnailKey),
+          thumbnail_url: await getMediaUrl(thumbnailKey || updated.storage_key),
           status: updated.status,
           created_at: updated.created_at,
         },

--- a/app/w/[slug]/gallery/page.tsx
+++ b/app/w/[slug]/gallery/page.tsx
@@ -581,19 +581,29 @@ export default function GalleryPage() {
                     }
                   }}
                 >
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    src={item.thumbnail_url}
-                    alt=""
-                    className="w-full h-full object-cover"
-                    loading="lazy"
-                    onError={(e) => {
-                      const img = e.currentTarget;
-                      if (img.src !== item.url) {
-                        img.src = item.url;
-                      }
-                    }}
-                  />
+                  {item.type === 'video' ? (
+                    <video
+                      src={`${item.url}#t=0.1`}
+                      className="w-full h-full object-cover"
+                      preload="metadata"
+                      muted
+                      playsInline
+                    />
+                  ) : (
+                    /* eslint-disable-next-line @next/next/no-img-element */
+                    <img
+                      src={item.thumbnail_url}
+                      alt=""
+                      className="w-full h-full object-cover"
+                      loading="lazy"
+                      onError={(e) => {
+                        const img = e.currentTarget;
+                        if (img.src !== item.url) {
+                          img.src = item.url;
+                        }
+                      }}
+                    />
+                  )}
 
                   {/* Action overlay - shown on hover (desktop) or tap (mobile) */}
                   <div

--- a/app/w/[slug]/shared-gallery/page.tsx
+++ b/app/w/[slug]/shared-gallery/page.tsx
@@ -293,19 +293,29 @@ export default function SharedGalleryPage() {
                   }}
                   onClick={() => setSelectedItem(item)}
                 >
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    src={item.thumbnail_url}
-                    alt=""
-                    className="w-full h-full object-cover"
-                    loading="lazy"
-                    onError={(e) => {
-                      const img = e.currentTarget;
-                      if (img.src !== item.url) {
-                        img.src = item.url;
-                      }
-                    }}
-                  />
+                  {item.type === 'video' ? (
+                    <video
+                      src={`${item.url}#t=0.1`}
+                      className="w-full h-full object-cover"
+                      preload="metadata"
+                      muted
+                      playsInline
+                    />
+                  ) : (
+                    /* eslint-disable-next-line @next/next/no-img-element */
+                    <img
+                      src={item.thumbnail_url}
+                      alt=""
+                      className="w-full h-full object-cover"
+                      loading="lazy"
+                      onError={(e) => {
+                        const img = e.currentTarget;
+                        if (img.src !== item.url) {
+                          img.src = item.url;
+                        }
+                      }}
+                    />
+                  )}
 
                   {/* Gradient overlay at bottom */}
                   <div


### PR DESCRIPTION
- Gallery/shared-gallery now render a <video> element with #t=0.1 for video items so the first frame shows as a thumbnail instead of the broken <img> that tried to load a nonexistent thumbnail file.
- upload/complete no longer stores a bogus thumbnail_key for videos (previously it saved a key pointing to a file that was never created).
- Media API skips the uploads query entirely when typeFilter='portrait' so only AI portraits come back, not all uploads merged with them.

https://claude.ai/code/session_01A3JYPt5VgMUGZqzfzo28qB