### PR TITLE
Surface toast prompt on video thumbnails and in lightbox

### DIFF
--- a/app/api/v1/w/[slug]/media/[guestId]/route.ts
+++ b/app/api/v1/w/[slug]/media/[guestId]/route.ts
@@ -55,6 +55,7 @@ export async function GET(
       created_at: Date;
       event_name: string | null;
       favorited?: boolean;
+      prompt_answered?: string | null;
     };
     let uploadsResult: { rows: UploadRow[] } = { rows: [] };
 
@@ -91,7 +92,7 @@ export async function GET(
 
       const uploadsQuery = `
         SELECT u.id, u.type, u.storage_key, u.thumbnail_key, u.filter_applied,
-               u.duration_ms, u.created_at, e.name as event_name,
+               u.duration_ms, u.prompt_answered, u.created_at, e.name as event_name,
                CASE WHEN f.id IS NOT NULL THEN true ELSE false END as favorited
         FROM uploads u
         LEFT JOIN events e ON u.event_id = e.id
@@ -128,7 +129,7 @@ export async function GET(
       const portraitQuery = `
         SELECT a.id, 'portrait' as type, a.output_key as storage_key,
                a.output_key as thumbnail_key, a.style_id as filter_applied,
-               NULL as duration_ms, a.created_at, NULL as event_name
+               NULL as duration_ms, NULL as prompt_answered, a.created_at, NULL as event_name
         FROM ai_jobs a
         WHERE ${portraitConditions.join(' AND ')}
         ORDER BY a.created_at DESC
@@ -155,6 +156,7 @@ export async function GET(
       event_name: row.event_name || null,
       filter_applied: row.filter_applied || null,
       duration_ms: row.duration_ms || null,
+      prompt_answered: row.prompt_answered || null,
       favorited: row.favorited === true,
       created_at: row.created_at,
     })));

--- a/app/w/[slug]/gallery/page.tsx
+++ b/app/w/[slug]/gallery/page.tsx
@@ -718,6 +718,28 @@ export default function GalleryPage() {
                       {String(Math.floor((item.duration_ms % 60000) / 1000)).padStart(2, '0')}
                     </div>
                   )}
+
+                  {/* Toast prompt caption on video thumbnail */}
+                  {item.type === 'video' && item.prompt_answered && (
+                    <div
+                      className="absolute inset-x-0 bottom-0 px-2 py-1.5 pointer-events-none"
+                      style={{
+                        background: 'linear-gradient(to top, rgba(0,0,0,0.75) 0%, rgba(0,0,0,0.4) 60%, transparent 100%)',
+                        paddingRight: item.duration_ms ? 40 : 8,
+                      }}
+                    >
+                      <p
+                        className="text-white text-[10px] leading-tight line-clamp-2"
+                        style={{
+                          fontFamily: 'var(--font-display)',
+                          fontStyle: 'italic',
+                          textShadow: '0 1px 2px rgba(0,0,0,0.5)',
+                        }}
+                      >
+                        &ldquo;{item.prompt_answered}&rdquo;
+                      </p>
+                    </div>
+                  )}
                 </div>
               );
             })}
@@ -794,6 +816,37 @@ export default function GalleryPage() {
             )}
             <div className="w-10" />
           </div>
+
+          {/* Toast prompt caption */}
+          {selectedItem.type === 'video' && selectedItem.prompt_answered && (
+            <div className="px-6 pb-3 flex-shrink-0">
+              <div
+                className="mx-auto max-w-xl px-4 py-2.5 rounded-xl text-center"
+                style={{
+                  background: 'rgba(254, 252, 249, 0.08)',
+                  border: '1px solid rgba(198, 163, 85, 0.25)',
+                  backdropFilter: 'blur(8px)',
+                }}
+              >
+                <p
+                  className="text-[10px] uppercase tracking-[0.15em] mb-1"
+                  style={{ color: 'rgba(212, 168, 83, 0.7)' }}
+                >
+                  Answering
+                </p>
+                <p
+                  className="text-sm leading-snug"
+                  style={{
+                    fontFamily: 'var(--font-display)',
+                    fontStyle: 'italic',
+                    color: 'rgba(254, 252, 249, 0.92)',
+                  }}
+                >
+                  &ldquo;{selectedItem.prompt_answered}&rdquo;
+                </p>
+              </div>
+            </div>
+          )}
 
           {/* Image */}
           <div className="flex-1 flex items-center justify-center px-4 overflow-hidden">

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -119,6 +119,7 @@ export type MediaItem = {
   event_name: string | null;
   filter_applied: string | null;
   duration_ms: number | null;
+  prompt_answered: string | null;
   favorited: boolean;
   created_at: string;
 };


### PR DESCRIPTION
The prompt_answered column was being saved on upload but never returned by the media API or shown anywhere. Now:

- Media API returns prompt_answered for each video
- Gallery thumbnails show the prompt as an italic caption at the bottom with a dark gradient overlay, truncated to 2 lines
- Lightbox shows an "Answering" card with the full prompt above the video player

https://claude.ai/code/session_01A3JYPt5VgMUGZqzfzo28qB