### PR TITLE
Guest login fuzzy match + card-style gallery thumbnails

### DIFF
--- a/app/api/v1/w/[slug]/guests/search/route.ts
+++ b/app/api/v1/w/[slug]/guests/search/route.ts
@@ -3,6 +3,33 @@ import { getPool } from '@/lib/db/client';
 import { handleApiError, AppError } from '@/lib/errors';
 import { guestSearchSchema } from '@/lib/validation';
 
+const FUZZY_MAX_DISTANCE = 2;
+const FUZZY_MAX_RESULTS = 5;
+
+function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+
+  const prev = new Array(b.length + 1);
+  const curr = new Array(b.length + 1);
+  for (let j = 0; j <= b.length; j++) prev[j] = j;
+
+  for (let i = 1; i <= a.length; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(curr[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost);
+    }
+    for (let j = 0; j <= b.length; j++) prev[j] = curr[j];
+  }
+  return prev[b.length];
+}
+
+function normalize(s: string): string {
+  return s.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ slug: string }> }
@@ -20,7 +47,8 @@ export async function GET(
       throw new AppError('VALIDATION_ERROR', 'Search query must be at least 2 characters');
     }
 
-    const { q, limit } = parsed.data;
+    const { q } = parsed.data;
+    const query = normalize(q);
     const pool = getPool();
 
     // Resolve slug to wedding_id
@@ -35,31 +63,68 @@ export async function GET(
 
     const weddingId = weddingResult.rows[0].id;
 
-    // Search guests using trigram similarity
     const guestsResult = await pool.query(
-      `SELECT id, first_name, last_name
-       FROM guests
-       WHERE wedding_id = $1
-         AND (
-           first_name ILIKE $2
-           OR last_name ILIKE $2
-           OR (first_name || ' ' || last_name) ILIKE $2
-         )
-       ORDER BY
-         CASE WHEN first_name ILIKE $3 THEN 0 ELSE 1 END,
-         first_name ASC
-       LIMIT $4`,
-      [weddingId, `%${q}%`, `${q}%`, limit]
+      `SELECT id, first_name, last_name FROM guests WHERE wedding_id = $1`,
+      [weddingId]
     );
 
+    type Row = { id: string; first_name: string; last_name: string };
+    const rows: Row[] = guestsResult.rows;
+    const indexed = rows.map((g) => ({
+      id: g.id,
+      first_name: g.first_name,
+      last_name: g.last_name,
+      full: normalize(`${g.first_name} ${g.last_name}`),
+      first: normalize(g.first_name),
+    }));
+
+    // Rule 1: Exact full-name match (case-insensitive)
+    const exact = indexed.find((g) => g.full === query);
+    if (exact) {
+      return Response.json({
+        data: {
+          guests: [{ id: exact.id, first_name: exact.first_name, last_name: exact.last_name }],
+          match_type: 'exact' as const,
+        },
+      });
+    }
+
+    // Rule 3: Unique first-name match (only if query is a single word)
+    if (!query.includes(' ')) {
+      const firstMatches = indexed.filter((g) => g.first === query);
+      if (firstMatches.length === 1) {
+        const only = firstMatches[0];
+        return Response.json({
+          data: {
+            guests: [{ id: only.id, first_name: only.first_name, last_name: only.last_name }],
+            match_type: 'unique_first' as const,
+          },
+        });
+      }
+    }
+
+    // Rule 2: Fuzzy match (Levenshtein ≤ 2) on full name
+    const fuzzy = indexed
+      .map((g) => ({ guest: g, distance: levenshtein(query, g.full) }))
+      .filter((r) => r.distance <= FUZZY_MAX_DISTANCE)
+      .sort((a, b) => a.distance - b.distance)
+      .slice(0, FUZZY_MAX_RESULTS);
+
+    if (fuzzy.length > 0) {
+      return Response.json({
+        data: {
+          guests: fuzzy.map((f) => ({
+            id: f.guest.id,
+            first_name: f.guest.first_name,
+            last_name: f.guest.last_name,
+          })),
+          match_type: 'fuzzy' as const,
+        },
+      });
+    }
+
     return Response.json({
-      data: {
-        guests: guestsResult.rows.map((g: Record<string, string>) => ({
-          id: g.id,
-          first_name: g.first_name,
-          last_name: g.last_name,
-        })),
-      },
+      data: { guests: [], match_type: 'none' as const },
     });
   } catch (error) {
     return handleApiError(error);

--- a/app/w/[slug]/gallery/page.tsx
+++ b/app/w/[slug]/gallery/page.tsx
@@ -35,7 +35,6 @@ export default function GalleryPage() {
   const [selectedItem, setSelectedItem] = useState<MediaItem | null>(null);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-  const [activeThumbId, setActiveThumbId] = useState<string | null>(null);
   const [showAiModal, setShowAiModal] = useState(false);
   const [aiSourceItem, setAiSourceItem] = useState<MediaItem | null>(null);
   const [selectedAiStyle, setSelectedAiStyle] = useState<string | null>(null);
@@ -553,107 +552,51 @@ export default function GalleryPage() {
         </div>
       ) : (
         <>
-          <div className="grid grid-cols-3 gap-[3px] mt-5 sm:grid-cols-4">
+          <div className="grid grid-cols-3 gap-[6px] mt-5 sm:grid-cols-4">
             {items.map((item, i) => {
-              const showActions = activeThumbId === item.id;
               const uploaderName = guest.display_name || guest.first_name;
               return (
                 <div
                   key={item.id}
-                  className="aspect-square relative overflow-hidden cursor-pointer group"
+                  className="flex flex-col group"
                   style={{
-                    background: 'var(--bg-soft-cream)',
-                    borderRadius: i === 0 ? '10px 3px 3px 3px' : i === 2 ? '3px 10px 3px 3px' : 3,
-                  }}
-                  onClick={() => {
-                    // On mobile: first tap shows actions, second tap opens lightbox
-                    if ('ontouchstart' in window) {
-                      if (activeThumbId === item.id) {
-                        setSelectedItem(item);
-                        setShowDeleteConfirm(false);
-                        setActiveThumbId(null);
-                      } else {
-                        setActiveThumbId(item.id);
-                      }
-                    } else {
-                      setSelectedItem(item);
-                      setShowDeleteConfirm(false);
-                    }
+                    background: 'var(--bg-pure-white)',
+                    borderRadius: i === 0 ? '12px 6px 6px 6px' : i === 2 ? '6px 12px 6px 6px' : 6,
+                    border: '1px solid var(--border-light)',
+                    overflow: 'hidden',
                   }}
                 >
-                  {item.type === 'video' ? (
-                    <video
-                      src={`${item.url}#t=0.1`}
-                      className="w-full h-full object-cover"
-                      preload="metadata"
-                      muted
-                      playsInline
-                    />
-                  ) : (
-                    /* eslint-disable-next-line @next/next/no-img-element */
-                    <img
-                      src={item.thumbnail_url}
-                      alt=""
-                      className="w-full h-full object-cover"
-                      loading="lazy"
-                      onError={(e) => {
-                        const img = e.currentTarget;
-                        if (img.src !== item.url) {
-                          img.src = item.url;
-                        }
-                      }}
-                    />
-                  )}
-
-                  {/* Action overlay - shown on hover (desktop) or tap (mobile) */}
                   <div
-                    className={`absolute inset-0 flex items-end justify-center gap-3 pb-2 transition-opacity duration-200 ${showActions ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'}`}
-                    style={{
-                      background: 'linear-gradient(to top, rgba(0,0,0,0.6) 0%, rgba(0,0,0,0.15) 50%, transparent 100%)',
+                    className="aspect-square relative overflow-hidden cursor-pointer"
+                    style={{ background: 'var(--bg-soft-cream)' }}
+                    onClick={() => {
+                      setSelectedItem(item);
+                      setShowDeleteConfirm(false);
                     }}
                   >
-                    <button
-                      onClick={(e) => { e.stopPropagation(); handleFavorite(item); }}
-                      className="p-1.5 rounded-full"
-                      style={{ background: 'rgba(255,255,255,0.2)', backdropFilter: 'blur(8px)' }}
-                      title={item.favorited ? 'Unsave' : 'Save'}
-                    >
-                      <svg width="16" height="16" viewBox="0 0 24 24"
-                        fill={item.favorited ? '#ef4444' : 'none'}
-                        stroke={item.favorited ? '#ef4444' : 'white'}
-                        strokeWidth="2"
-                      >
-                        <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
-                      </svg>
-                    </button>
-                    <button
-                      onClick={(e) => { e.stopPropagation(); handleDownload(item); }}
-                      className="p-1.5 rounded-full"
-                      style={{ background: 'rgba(255,255,255,0.2)', backdropFilter: 'blur(8px)' }}
-                      title="Download"
-                    >
-                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2">
-                        <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
-                        <polyline points="7 10 12 15 17 10" />
-                        <line x1="12" y1="15" x2="12" y2="3" />
-                      </svg>
-                    </button>
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setSelectedItem(item);
-                        setShowDeleteConfirm(true);
-                      }}
-                      className="p-1.5 rounded-full"
-                      style={{ background: 'rgba(255,255,255,0.2)', backdropFilter: 'blur(8px)' }}
-                      title="Delete"
-                    >
-                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2">
-                        <polyline points="3 6 5 6 21 6" />
-                        <path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2" />
-                      </svg>
-                    </button>
-                  </div>
+                    {item.type === 'video' ? (
+                      <video
+                        src={`${item.url}#t=0.1`}
+                        className="w-full h-full object-cover"
+                        preload="metadata"
+                        muted
+                        playsInline
+                      />
+                    ) : (
+                      /* eslint-disable-next-line @next/next/no-img-element */
+                      <img
+                        src={item.thumbnail_url}
+                        alt=""
+                        className="w-full h-full object-cover"
+                        loading="lazy"
+                        onError={(e) => {
+                          const img = e.currentTarget;
+                          if (img.src !== item.url) {
+                            img.src = item.url;
+                          }
+                        }}
+                      />
+                    )}
 
                   {/* Uploader name badge */}
                   {uploaderName && (
@@ -776,6 +719,61 @@ export default function GalleryPage() {
                       </p>
                     </div>
                   )}
+                  </div>
+
+                  {/* Bottom action strip */}
+                  <div
+                    className="flex items-center justify-end gap-1 px-2"
+                    style={{
+                      height: 32,
+                      background: 'var(--bg-pure-white)',
+                      borderTop: '0.5px solid var(--border-light)',
+                    }}
+                  >
+                    <button
+                      onClick={(e) => { e.stopPropagation(); handleFavorite(item); }}
+                      disabled={actionLoading === 'favorite'}
+                      className="p-1.5 rounded-full transition-colors hover:bg-[var(--bg-soft-cream)]"
+                      title={item.favorited ? 'Unsave' : 'Save'}
+                      style={{ background: 'transparent', border: 'none', cursor: 'pointer' }}
+                    >
+                      <svg width="15" height="15" viewBox="0 0 24 24"
+                        fill={item.favorited ? '#ef4444' : 'none'}
+                        stroke={item.favorited ? '#ef4444' : 'var(--text-secondary)'}
+                        strokeWidth="1.8"
+                      >
+                        <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
+                      </svg>
+                    </button>
+                    <button
+                      onClick={(e) => { e.stopPropagation(); handleDownload(item); }}
+                      disabled={actionLoading === 'download'}
+                      className="p-1.5 rounded-full transition-colors hover:bg-[var(--bg-soft-cream)]"
+                      title="Download"
+                      style={{ background: 'transparent', border: 'none', cursor: 'pointer' }}
+                    >
+                      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="var(--text-secondary)" strokeWidth="1.8">
+                        <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
+                        <polyline points="7 10 12 15 17 10" />
+                        <line x1="12" y1="15" x2="12" y2="3" />
+                      </svg>
+                    </button>
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setSelectedItem(item);
+                        setShowDeleteConfirm(true);
+                      }}
+                      className="p-1.5 rounded-full transition-colors hover:bg-[var(--bg-soft-cream)]"
+                      title="Delete"
+                      style={{ background: 'transparent', border: 'none', cursor: 'pointer' }}
+                    >
+                      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="var(--text-secondary)" strokeWidth="1.8">
+                        <polyline points="3 6 5 6 21 6" />
+                        <path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2" />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
               );
             })}

--- a/app/w/[slug]/page.tsx
+++ b/app/w/[slug]/page.tsx
@@ -11,6 +11,7 @@ export default function GuestRegistrationPage() {
   const [searchResults, setSearchResults] = useState<
     { id: string; first_name: string; last_name: string }[]
   >([]);
+  const [matchType, setMatchType] = useState<'exact' | 'unique_first' | 'fuzzy' | 'none' | null>(null);
   const [isSearching, setIsSearching] = useState(false);
   const [isRegistering, setIsRegistering] = useState(false);
   const [error, setError] = useState('');
@@ -27,6 +28,7 @@ export default function GuestRegistrationPage() {
     async (query: string) => {
       if (query.length < 2) {
         setSearchResults([]);
+        setMatchType(null);
         return;
       }
 
@@ -36,8 +38,9 @@ export default function GuestRegistrationPage() {
           `/api/v1/w/${slug}/guests/search?q=${encodeURIComponent(query)}`
         );
         const data = await res.json();
-        if (data.data?.guests) {
-          setSearchResults(data.data.guests);
+        if (data.data) {
+          setSearchResults(data.data.guests || []);
+          setMatchType(data.data.match_type || 'none');
         }
       } catch (err) {
         console.error('Search failed:', err);
@@ -213,40 +216,74 @@ export default function GuestRegistrationPage() {
           )}
         </div>
 
+        {/* Match-type label above results */}
+        {searchResults.length > 0 && matchType === 'fuzzy' && (
+          <p
+            className="text-[11px] uppercase tracking-widest mb-2"
+            style={{ color: 'var(--text-tertiary)', letterSpacing: '0.15em' }}
+          >
+            Did you mean?
+          </p>
+        )}
+
         {/* Search Results */}
         {searchResults.length > 0 && (
           <div
             className="rounded-2xl overflow-hidden mb-4"
             style={{
               background: 'var(--bg-pure-white)',
-              border: '1px solid var(--border-light)',
-              boxShadow: 'var(--shadow-medium)',
+              border: matchType === 'exact'
+                ? '1px solid var(--color-gold-rule)'
+                : '1px solid var(--border-light)',
+              boxShadow: matchType === 'exact'
+                ? '0 8px 24px rgba(198, 163, 85, 0.15)'
+                : 'var(--shadow-medium)',
             }}
           >
-            {searchResults.map((guest) => (
+            {searchResults.map((guest, idx) => (
               <button
                 key={guest.id}
                 onClick={() => handleSelectGuest(guest)}
                 disabled={isRegistering}
                 className="w-full px-6 py-4 text-left hover:bg-[#F7F3ED] transition-colors flex items-center gap-3 disabled:opacity-50"
                 style={{
-                  borderBottom: '1px solid var(--border-light)',
+                  borderBottom: idx < searchResults.length - 1 ? '1px solid var(--border-light)' : 'none',
                   fontFamily: 'var(--font-body)',
                 }}
               >
                 <div
                   className="w-10 h-10 rounded-full flex items-center justify-center text-sm font-semibold flex-shrink-0"
                   style={{
-                    background: 'var(--color-terracotta-light)',
-                    color: 'var(--color-terracotta-dark)',
+                    background: matchType === 'exact'
+                      ? 'linear-gradient(135deg, var(--color-gold-dark), var(--color-gold))'
+                      : 'var(--color-terracotta-light)',
+                    color: matchType === 'exact' ? '#FDFBF7' : 'var(--color-terracotta-dark)',
                   }}
                 >
                   {guest.first_name[0]}
                   {guest.last_name[0]}
                 </div>
-                <span style={{ color: 'var(--text-primary)' }}>
-                  {guest.first_name} {guest.last_name}
-                </span>
+                <div className="flex-1 min-w-0">
+                  <span className="block" style={{ color: 'var(--text-primary)' }}>
+                    {guest.first_name} {guest.last_name}
+                  </span>
+                  {matchType === 'exact' && (
+                    <span
+                      className="text-[11px] uppercase tracking-widest"
+                      style={{ color: 'var(--color-gold-dark)', letterSpacing: '0.12em' }}
+                    >
+                      Continue as you
+                    </span>
+                  )}
+                  {matchType === 'unique_first' && (
+                    <span
+                      className="text-xs"
+                      style={{ color: 'var(--text-tertiary)' }}
+                    >
+                      Is this you?
+                    </span>
+                  )}
+                </div>
               </button>
             ))}
           </div>
@@ -265,14 +302,14 @@ export default function GuestRegistrationPage() {
         )}
 
         {searchQuery.length >= 2 &&
-          searchResults.length === 0 &&
+          matchType === 'none' &&
           !isSearching && (
             <p
               className="text-sm py-4"
               style={{ color: 'var(--text-secondary)' }}
             >
-              We couldn&apos;t find that name on the guest list. Try a different
-              spelling?
+              We couldn&apos;t find that name on the guest list. Try your full
+              name as it appears on the invitation?
             </p>
           )}
 
@@ -280,7 +317,7 @@ export default function GuestRegistrationPage() {
           className="text-xs mt-6"
           style={{ color: 'var(--text-tertiary)' }}
         >
-          Start typing your name to find yourself on the guest list
+          Enter your full name as it appears on the invitation
         </p>
       </div>
     </div>


### PR DESCRIPTION
Guest search now applies three rules server-side and returns a match_type so the login UI can adapt:
- exact full-name match (case-insensitive) shows a gold-bordered card with "Continue as you" kicker
- query with no space that uniquely matches a first name returns that single guest with "Is this you?" subtitle
- otherwise Levenshtein distance ≤ 2 against full names returns up to 5 closest matches under a "Did you mean?" label
- everything else returns an empty list so typing a partial substring no longer leaks the guest list

Gallery tiles are now proper cards: aspect-square thumbnail on top with a white action strip underneath holding favorite/download/delete icons. This removes the old hover overlay that collided with the toast caption. First-tap-shows-actions behavior on mobile is gone — the buttons are always present in the strip, so mobile users just tap the image area to open the lightbox.

https://claude.ai/code/session_01A3JYPt5VgMUGZqzfzo28qB