### PR TITLE
Fix style guide thumbnails to preserve original aspect ratio

### DIFF
--- a/app/dashboard/[weddingId]/settings/page.tsx
+++ b/app/dashboard/[weddingId]/settings/page.tsx
@@ -681,9 +681,9 @@ export default function SettingsPage({ params }: { params: Promise<{ weddingId: 
                         src={img.url}
                         alt="Style guide"
                         style={{
-                          width: 100,
-                          height: 130,
-                          objectFit: 'cover',
+                          maxWidth: 160,
+                          maxHeight: 130,
+                          objectFit: 'contain',
                           borderRadius: 10,
                           border: '1px solid var(--border-light)',
                         }}
@@ -962,9 +962,9 @@ export default function SettingsPage({ params }: { params: Promise<{ weddingId: 
                                 src={img.url}
                                 alt="Style guide"
                                 style={{
-                                  width: 72,
-                                  height: 96,
-                                  objectFit: 'cover',
+                                  maxWidth: 120,
+                                  maxHeight: 96,
+                                  objectFit: 'contain',
                                   borderRadius: 8,
                                   border: '1px solid var(--border-light)',
                                 }}


### PR DESCRIPTION
Changed from fixed portrait dimensions (width/height with object-fit: cover) to max dimensions with object-fit: contain, so landscape photos display in their uploaded aspect ratio instead of being cropped to portrait.

https://claude.ai/code/session_01A3JYPt5VgMUGZqzfzo28qB