### PR TITLE
Fix clearing event fields: send null instead of undefined on empty

### DIFF
--- a/app/dashboard/[weddingId]/settings/page.tsx
+++ b/app/dashboard/[weddingId]/settings/page.tsx
@@ -315,14 +315,14 @@ export default function SettingsPage({ params }: { params: Promise<{ weddingId: 
 
     const body = {
       name,
-      date: date || undefined,
-      start_time: startTime || undefined,
-      end_time: endTime || undefined,
-      venue_name: venueName || undefined,
-      venue_address: venueAddress || undefined,
-      dress_code: dressCode || undefined,
-      description: description || undefined,
-      logistics: logistics || undefined,
+      date: date || null,
+      start_time: startTime || null,
+      end_time: endTime || null,
+      venue_name: venueName || null,
+      venue_address: venueAddress || null,
+      dress_code: dressCode || null,
+      description: description || null,
+      logistics: logistics || null,
     };
 
     try {


### PR DESCRIPTION
When a field was cleared (e.g. deleting the description), the empty string was converted to undefined via `|| undefined`, which omitted the field from the request body entirely. The server then skipped the update, leaving the old value in the database. Sending null instead ensures the server sets the column to NULL.

https://claude.ai/code/session_01A3JYPt5VgMUGZqzfzo28qB