### PR TITLE
Fix guest-facing style guide photos cropping to portrait

### DIFF
--- a/app/w/[slug]/schedule/page.tsx
+++ b/app/w/[slug]/schedule/page.tsx
@@ -458,9 +458,9 @@ export default async function SchedulePage({
                                 src={url}
                                 alt={`Style guide ${imgIdx + 1}`}
                                 style={{
-                                  width: event.style_guide_urls.length === 1 ? '100%' : 180,
-                                  height: event.style_guide_urls.length === 1 ? 'auto' : 240,
-                                  objectFit: 'cover',
+                                  maxHeight: 280,
+                                  width: event.style_guide_urls.length === 1 ? '100%' : 'auto',
+                                  objectFit: 'contain',
                                   borderRadius: 10,
                                   flexShrink: 0,
                                   border: '0.5px solid rgba(196, 112, 75, 0.1)',


### PR DESCRIPTION
Multi-photo layouts used a fixed height with object-fit: cover, which cropped landscape images into portrait frames. Changed to maxHeight with object-fit: contain so photos display in their original aspect ratio.

https://claude.ai/code/session_01A3JYPt5VgMUGZqzfzo28qB