### PR TITLE
Address all household members by name in guest emails

### DIFF
--- a/app/api/v1/dashboard/weddings/[weddingId]/emails/send/route.ts
+++ b/app/api/v1/dashboard/weddings/[weddingId]/emails/send/route.ts
@@ -24,7 +24,18 @@ interface GuestRow {
   first_name: string;
   last_name: string;
   email: string | null;
+  party_id: string | null;
+  party_role: string | null;
   rsvp_status: 'pending' | 'attending' | 'declined';
+}
+
+function formatGreeting(names: string[]): string {
+  const filtered = names.filter(n => n && n !== '-' && n.toLowerCase() !== 'guest');
+  if (filtered.length === 0) return '';
+  if (filtered.length === 1) return `Hello ${filtered[0]},`;
+  const last = filtered[filtered.length - 1];
+  const rest = filtered.slice(0, -1);
+  return `Hello ${rest.join(', ')} & ${last},`;
 }
 
 /**
@@ -68,21 +79,21 @@ export async function POST(
         throw new AppError('VALIDATION_ERROR', 'No guests selected');
       }
       guestsResult = await pool.query(
-        `SELECT id, first_name, last_name, email, rsvp_status
+        `SELECT id, first_name, last_name, email, party_id, party_role, rsvp_status
          FROM guests
          WHERE wedding_id = $1 AND id = ANY($2::uuid[]) AND email IS NOT NULL AND email != ''`,
         [weddingId, parsed.guest_ids]
       );
     } else if (parsed.audience === 'all') {
       guestsResult = await pool.query(
-        `SELECT id, first_name, last_name, email, rsvp_status
+        `SELECT id, first_name, last_name, email, party_id, party_role, rsvp_status
          FROM guests
          WHERE wedding_id = $1 AND email IS NOT NULL AND email != ''`,
         [weddingId]
       );
     } else {
       guestsResult = await pool.query(
-        `SELECT id, first_name, last_name, email, rsvp_status
+        `SELECT id, first_name, last_name, email, party_id, party_role, rsvp_status
          FROM guests
          WHERE wedding_id = $1 AND rsvp_status = $2 AND email IS NOT NULL AND email != ''`,
         [weddingId, parsed.audience]
@@ -99,8 +110,42 @@ export async function POST(
       });
     }
 
-    // Each email is personalized with the guest's name in the greeting,
-    // so send them one-at-a-time rather than as one blast.
+    // Look up all party members (including those without email) so we can
+    // greet the whole household: "Hello Rahul, Sonia, Arush & Alina,"
+    const partyIds = [...new Set(guests.map(g => g.party_id).filter(Boolean))] as string[];
+
+    const partyMembersMap = new Map<string, string[]>();
+    if (partyIds.length > 0) {
+      const membersResult = await pool.query(
+        `SELECT first_name, party_id, party_role
+         FROM guests
+         WHERE wedding_id = $1 AND party_id = ANY($2::uuid[])
+         ORDER BY party_id,
+           CASE party_role WHEN 'primary' THEN 0 WHEN 'partner' THEN 1 WHEN 'child' THEN 2 ELSE 3 END`,
+        [weddingId, partyIds]
+      );
+      for (const row of membersResult.rows) {
+        const list = partyMembersMap.get(row.party_id) || [];
+        list.push(row.first_name);
+        partyMembersMap.set(row.party_id, list);
+      }
+    }
+
+    // Deduplicate: one email per party. For guests without a party, send individually.
+    const seen = new Set<string>();
+    const recipients: Array<{ email: string; greeting: string }> = [];
+
+    for (const g of guests) {
+      if (g.party_id) {
+        if (seen.has(g.party_id)) continue;
+        seen.add(g.party_id);
+        const names = partyMembersMap.get(g.party_id) || [g.first_name];
+        recipients.push({ email: g.email!, greeting: formatGreeting(names) });
+      } else {
+        recipients.push({ email: g.email!, greeting: formatGreeting([g.first_name]) });
+      }
+    }
+
     const replyTo =
       parsed.reply_to && parsed.reply_to.length > 0
         ? parsed.reply_to
@@ -113,12 +158,13 @@ export async function POST(
     };
 
     // Simple rate-limited loop: ~2 req/s to respect free-tier limits.
-    for (let i = 0; i < guests.length; i += 2) {
-      const chunk = guests.slice(i, i + 2);
+    for (let i = 0; i < recipients.length; i += 2) {
+      const chunk = recipients.slice(i, i + 2);
       const chunkResults = await Promise.all(
-        chunk.map(async (g) => {
+        chunk.map(async (r) => {
           const template = buildGuestEmail({
             weddingName,
+            greeting: r.greeting,
             heading: parsed.heading,
             body: parsed.body,
             ctaLabel: parsed.cta_label || undefined,
@@ -128,13 +174,13 @@ export async function POST(
           });
 
           const res = await sendEmail({
-            to: g.email!,
+            to: r.email,
             subject: parsed.subject,
             html: template.html,
             text: template.text,
             replyTo,
           });
-          return { email: g.email!, ...res };
+          return { email: r.email, ...res };
         })
       );
 
@@ -147,7 +193,7 @@ export async function POST(
         }
       }
 
-      if (i + 2 < guests.length) {
+      if (i + 2 < recipients.length) {
         await new Promise((resolve) => setTimeout(resolve, 600));
       }
     }

--- a/app/dashboard/[weddingId]/emails/page.tsx
+++ b/app/dashboard/[weddingId]/emails/page.tsx
@@ -493,7 +493,7 @@ RESEND_REPLY_TO=shriyaneilwedding@gmail.com`}
             style={{ ...inputStyle, resize: 'vertical', fontFamily: 'var(--font-body)', lineHeight: 1.6 }}
           />
           <p style={{ margin: '6px 0 0', fontSize: 11, color: 'var(--text-tertiary)', fontFamily: 'var(--font-body)' }}>
-            Each guest will see &quot;Hi [their first name],&quot; automatically at the top.
+            Each household will see a personalized greeting, e.g. &quot;Hello Rahul, Sonia &amp; Alina,&quot;
           </p>
         </div>
 

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -1,14 +1,6 @@
-/**
- * Minimal branded email template. Returns { html, text } from a plain-text
- * message body. Keeps things simple — no external template engine required.
- *
- * Intentionally has NO "Hi <name>" greeting: guests imported from a CSV are
- * stored individually without their plus-ones, so a personal greeting reads
- * weird when only one member of a couple actually receives the email. The
- * heading + body carry the message instead.
- */
 export interface BuildEmailArgs {
   weddingName: string;
+  greeting?: string;
   heading: string;
   body: string;
   ctaLabel?: string;
@@ -35,6 +27,7 @@ function bodyToHtml(body: string): string {
 export function buildGuestEmail(args: BuildEmailArgs): { html: string; text: string } {
   const {
     weddingName,
+    greeting,
     heading,
     body,
     ctaLabel,
@@ -83,9 +76,14 @@ export function buildGuestEmail(args: BuildEmailArgs): { html: string; text: str
               <td style="padding:16px 32px 0;text-align:center;">
                 <h1 style="margin:0;font-family:Georgia,serif;font-size:26px;font-weight:500;color:#1b1c1a;line-height:1.25;">${escapeHtml(heading)}</h1>
               </td>
-            </tr>
+            </tr>${greeting ? `
             <tr>
-              <td style="padding:24px 36px 32px;font-family:Georgia,serif;font-size:15px;line-height:1.65;color:#3b3a36;">
+              <td style="padding:20px 36px 0;font-family:Georgia,serif;font-size:16px;color:#3b3a36;">
+                ${escapeHtml(greeting)}
+              </td>
+            </tr>` : ''}
+            <tr>
+              <td style="padding:${greeting ? '12px' : '24px'} 36px 32px;font-family:Georgia,serif;font-size:15px;line-height:1.65;color:#3b3a36;">
                 ${bodyHtml}
                 ${ctaHtml}
                 ${footer}
@@ -105,7 +103,9 @@ export function buildGuestEmail(args: BuildEmailArgs): { html: string; text: str
   </body>
 </html>`;
 
-  const textLines = [body];
+  const textLines: string[] = [];
+  if (greeting) textLines.push(greeting, '');
+  textLines.push(body);
   if (ctaLabel && ctaUrl) {
     textLines.push('', `${ctaLabel}: ${ctaUrl}`);
   }


### PR DESCRIPTION
Emails now greet the entire party: "Hello Rahul, Sonia, Arush & Alina," instead of sending generic emails with no personalization. The send logic looks up all members of each party_id, deduplicates to one email per household, and builds a personalized greeting from everyone's first names (skipping placeholder names like "-" or "Guest").

- Added greeting field to email template (HTML + plaintext)
- Send endpoint queries party members and deduplicates by party_id
- Updated UI hint to describe household-level greeting

https://claude.ai/code/session_01A3JYPt5VgMUGZqzfzo28qB