### PR TITLE
Guest links: add Invite button and RSVP passcode copy-and-toast

### DIFF
--- a/app/api/v1/dashboard/weddings/[weddingId]/route.ts
+++ b/app/api/v1/dashboard/weddings/[weddingId]/route.ts
@@ -19,6 +19,18 @@ const updateWeddingSchema = z.object({
     .nullable()
     .optional()
     .or(z.literal('')),
+  // Passcode for the external wedding site — copied to clipboard when the
+  // guest taps the RSVP button. Plain string; the user sees this themselves.
+  rsvp_passcode: z.string().max(100).nullable().optional().or(z.literal('')),
+  // Invite link (Canva, Paperless Post, etc.) — separate button on the guest
+  // home next to the RSVP button.
+  invite_url: z
+    .string()
+    .max(500)
+    .url()
+    .nullable()
+    .optional()
+    .or(z.literal('')),
 });
 
 /**
@@ -63,13 +75,19 @@ export async function PATCH(
       values.push(parsed.venue_lng);
     }
 
-    // rsvp_url lives inside the config JSONB (empty string / null clears it).
-    if (parsed.rsvp_url !== undefined) {
-      const next =
-        typeof parsed.rsvp_url === 'string' && parsed.rsvp_url.trim()
-          ? parsed.rsvp_url.trim()
-          : null;
-      sets.push(`config = jsonb_set(COALESCE(config, '{}'::jsonb), '{rsvp_url}', $${idx++}::jsonb, true)`);
+    // These three all live inside the wedding config JSONB. Empty string and
+    // explicit null both clear the field.
+    const configFields: Array<{ key: string; value: string | null | undefined }> = [
+      { key: 'rsvp_url', value: parsed.rsvp_url },
+      { key: 'rsvp_passcode', value: parsed.rsvp_passcode },
+      { key: 'invite_url', value: parsed.invite_url },
+    ];
+    for (const f of configFields) {
+      if (f.value === undefined) continue;
+      const next = typeof f.value === 'string' && f.value.trim() ? f.value.trim() : null;
+      sets.push(
+        `config = jsonb_set(COALESCE(config, '{}'::jsonb), '{${f.key}}', $${idx++}::jsonb, true)`
+      );
       values.push(JSON.stringify(next));
     }
 

--- a/app/api/v1/w/[slug]/config/route.ts
+++ b/app/api/v1/w/[slug]/config/route.ts
@@ -134,6 +134,12 @@ export async function GET(
       rsvp_url: typeof config.rsvp_url === 'string' && config.rsvp_url.trim()
         ? config.rsvp_url.trim()
         : null,
+      rsvp_passcode: typeof config.rsvp_passcode === 'string' && config.rsvp_passcode.trim()
+        ? config.rsvp_passcode.trim()
+        : null,
+      invite_url: typeof config.invite_url === 'string' && config.invite_url.trim()
+        ? config.invite_url.trim()
+        : null,
       events,
       features: {
         social_feed: packageConfig.social_feed ?? false,

--- a/app/dashboard/[weddingId]/layout.tsx
+++ b/app/dashboard/[weddingId]/layout.tsx
@@ -69,7 +69,7 @@ export default function WeddingManageLayout({
       label: 'Guest experience',
       items: [
         { href: `/dashboard/${weddingId}/guests`, label: 'Guests', icon: 'M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197m13.5-9a2.5 2.5 0 11-5 0 2.5 2.5 0 015 0z' },
-        { href: `/dashboard/${weddingId}/rsvp`, label: 'RSVP', icon: 'M5 13l4 4L19 7' },
+        { href: `/dashboard/${weddingId}/rsvp`, label: 'RSVP & Invite', icon: 'M5 13l4 4L19 7' },
         { href: `/dashboard/${weddingId}/emails`, label: 'Emails', icon: 'M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2zm0 0l8 7 8-7' },
         { href: `/dashboard/${weddingId}/faq`, label: 'FAQ', icon: 'M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z' },
         { href: `/dashboard/${weddingId}/knowledge`, label: 'Knowledge', icon: 'M4 19.5A2.5 2.5 0 016.5 17H20M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z' },

--- a/app/dashboard/[weddingId]/rsvp/page.tsx
+++ b/app/dashboard/[weddingId]/rsvp/page.tsx
@@ -2,10 +2,18 @@
 
 import { useState, useEffect, useCallback, use } from 'react';
 
+interface LoadedConfig {
+  rsvp_url: string;
+  rsvp_passcode: string;
+  invite_url: string;
+}
+
+const EMPTY: LoadedConfig = { rsvp_url: '', rsvp_passcode: '', invite_url: '' };
+
 export default function RsvpLinkPage({ params }: { params: Promise<{ weddingId: string }> }) {
   const { weddingId } = use(params);
-  const [rsvpUrl, setRsvpUrl] = useState('');
-  const [initialUrl, setInitialUrl] = useState('');
+  const [values, setValues] = useState<LoadedConfig>(EMPTY);
+  const [initial, setInitial] = useState<LoadedConfig>(EMPTY);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [savedAt, setSavedAt] = useState<Date | null>(null);
@@ -14,14 +22,16 @@ export default function RsvpLinkPage({ params }: { params: Promise<{ weddingId: 
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      // Reuse the overview endpoint — it already returns the wedding row
-      // including config. No need for a dedicated GET for a single field.
       const res = await fetch(`/api/v1/dashboard/weddings/${weddingId}/overview`);
       const data = await res.json();
-      const current =
-        (data?.wedding?.config?.rsvp_url as string | null | undefined) ?? '';
-      setRsvpUrl(current || '');
-      setInitialUrl(current || '');
+      const cfg = (data?.wedding?.config ?? {}) as Record<string, unknown>;
+      const next: LoadedConfig = {
+        rsvp_url: typeof cfg.rsvp_url === 'string' ? cfg.rsvp_url : '',
+        rsvp_passcode: typeof cfg.rsvp_passcode === 'string' ? cfg.rsvp_passcode : '',
+        invite_url: typeof cfg.invite_url === 'string' ? cfg.invite_url : '',
+      };
+      setValues(next);
+      setInitial(next);
     } catch {
       setError('Failed to load');
     } finally {
@@ -38,23 +48,38 @@ export default function RsvpLinkPage({ params }: { params: Promise<{ weddingId: 
     setError('');
     setSavedAt(null);
     try {
-      const trimmed = rsvpUrl.trim();
-      // Surface the obvious error before hitting the server.
-      if (trimmed && !/^https?:\/\//i.test(trimmed)) {
-        setError('URL must start with http:// or https://');
+      const rsvp = values.rsvp_url.trim();
+      const invite = values.invite_url.trim();
+      if (rsvp && !/^https?:\/\//i.test(rsvp)) {
+        setError('RSVP URL must start with http:// or https://');
+        setSaving(false);
+        return;
+      }
+      if (invite && !/^https?:\/\//i.test(invite)) {
+        setError('Invite URL must start with http:// or https://');
         setSaving(false);
         return;
       }
       const res = await fetch(`/api/v1/dashboard/weddings/${weddingId}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ rsvp_url: trimmed || null }),
+        body: JSON.stringify({
+          rsvp_url: rsvp || null,
+          // Passcode without an RSVP URL is nonsense — drop it on the server
+          // side rather than error, but keep what the user typed locally.
+          rsvp_passcode: values.rsvp_passcode.trim() || null,
+          invite_url: invite || null,
+        }),
       });
       const json = await res.json().catch(() => ({}));
-      if (!res.ok) {
-        throw new Error(json?.error?.message || 'Save failed');
-      }
-      setInitialUrl(trimmed);
+      if (!res.ok) throw new Error(json?.error?.message || 'Save failed');
+      const saved: LoadedConfig = {
+        rsvp_url: rsvp,
+        rsvp_passcode: values.rsvp_passcode.trim(),
+        invite_url: invite,
+      };
+      setInitial(saved);
+      setValues(saved);
       setSavedAt(new Date());
       setTimeout(() => setSavedAt(null), 2500);
     } catch (err) {
@@ -64,11 +89,10 @@ export default function RsvpLinkPage({ params }: { params: Promise<{ weddingId: 
     }
   };
 
-  const clear = () => {
-    setRsvpUrl('');
-  };
-
-  const dirty = rsvpUrl.trim() !== initialUrl.trim();
+  const dirty =
+    values.rsvp_url.trim() !== initial.rsvp_url.trim() ||
+    values.rsvp_passcode.trim() !== initial.rsvp_passcode.trim() ||
+    values.invite_url.trim() !== initial.invite_url.trim();
 
   return (
     <div style={{ maxWidth: 720 }}>
@@ -82,7 +106,7 @@ export default function RsvpLinkPage({ params }: { params: Promise<{ weddingId: 
             margin: 0,
           }}
         >
-          RSVP link
+          RSVP &amp; Invite
         </h1>
         <p
           style={{
@@ -91,12 +115,12 @@ export default function RsvpLinkPage({ params }: { params: Promise<{ weddingId: 
             fontFamily: 'var(--font-body)',
             marginTop: 4,
             lineHeight: 1.55,
-            maxWidth: 560,
+            maxWidth: 580,
           }}
         >
-          Guests see an <strong>RSVP</strong> button in the header of the guest app that sends
-          them to this URL — typically your Zola or The Knot wedding site. Leave blank to hide
-          the button.
+          Guests see up to two buttons on the home page — one to RSVP (usually your Zola or
+          Joy site) and one to view the invite (Canva, PDF, etc.). Leave either blank to hide
+          that button.
         </p>
       </div>
 
@@ -107,46 +131,46 @@ export default function RsvpLinkPage({ params }: { params: Promise<{ weddingId: 
           background: 'var(--bg-pure-white)',
           border: '1px solid var(--border-light)',
           boxShadow: '0 2px 8px rgba(0,0,0,0.02)',
+          marginBottom: 14,
         }}
       >
         {loading ? (
-          <div className="skeleton" style={{ width: '100%', height: 48, borderRadius: 10 }} />
+          <div className="skeleton" style={{ width: '100%', height: 180, borderRadius: 10 }} />
         ) : (
-          <>
-            <label
-              style={{
-                display: 'block',
-                fontSize: 11,
-                textTransform: 'uppercase',
-                letterSpacing: '0.5px',
-                color: 'var(--text-tertiary)',
-                marginBottom: 6,
-                fontFamily: 'var(--font-body)',
-                fontWeight: 500,
-              }}
-            >
-              External RSVP URL
-            </label>
-            <input
-              type="url"
-              value={rsvpUrl}
-              onChange={(e) => setRsvpUrl(e.target.value)}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+            {/* RSVP URL */}
+            <Field
+              label="RSVP URL"
+              hint="Where guests go to RSVP — typically your Zola / Joy / Knot site."
               placeholder="https://withjoy.com/shriya-and-neil"
-              style={{
-                width: '100%',
-                padding: '10px 12px',
-                borderRadius: 10,
-                border: '1px solid var(--border-light)',
-                background: 'var(--bg-pure-white)',
-                fontSize: 14,
-                fontFamily: 'var(--font-body)',
-                color: 'var(--text-primary)',
-                outline: 'none',
-                boxSizing: 'border-box',
-              }}
+              type="url"
+              value={values.rsvp_url}
+              onChange={(v) => setValues({ ...values, rsvp_url: v })}
             />
 
-            <div style={{ display: 'flex', gap: 10, marginTop: 12, alignItems: 'center', flexWrap: 'wrap' }}>
+            {/* RSVP passcode */}
+            <Field
+              label="RSVP passcode (optional)"
+              hint="If your wedding site has a passcode, paste it here. We'll copy it to the guest's clipboard when they tap RSVP so they can just paste on the other side."
+              placeholder="e.g. love2026"
+              type="text"
+              value={values.rsvp_passcode}
+              onChange={(v) => setValues({ ...values, rsvp_passcode: v })}
+              disabled={!values.rsvp_url.trim()}
+              disabledMessage="Add an RSVP URL first."
+            />
+
+            {/* Invite URL */}
+            <Field
+              label="Invite URL"
+              hint="Link to the invite itself — Canva, Paperless Post, a Drive PDF, anything."
+              placeholder="https://www.canva.com/design/..."
+              type="url"
+              value={values.invite_url}
+              onChange={(v) => setValues({ ...values, invite_url: v })}
+            />
+
+            <div style={{ display: 'flex', gap: 10, alignItems: 'center', flexWrap: 'wrap' }}>
               <button
                 onClick={save}
                 disabled={saving || !dirty}
@@ -167,78 +191,160 @@ export default function RsvpLinkPage({ params }: { params: Promise<{ weddingId: 
               >
                 {saving ? 'Saving…' : 'Save'}
               </button>
-              {rsvpUrl && (
-                <button
-                  onClick={clear}
-                  style={{
-                    padding: '10px 14px',
-                    borderRadius: 10,
-                    border: '1px solid var(--border-light)',
-                    background: 'var(--bg-pure-white)',
-                    color: 'var(--color-terracotta)',
-                    fontSize: 13,
-                    fontWeight: 500,
-                    fontFamily: 'var(--font-body)',
-                    cursor: 'pointer',
-                  }}
-                >
-                  Clear
-                </button>
-              )}
               {savedAt && (
-                <span
-                  style={{
-                    fontSize: 12,
-                    color: 'var(--color-olive)',
-                    fontFamily: 'var(--font-body)',
-                  }}
-                >
+                <span style={{ fontSize: 12, color: 'var(--color-olive)', fontFamily: 'var(--font-body)' }}>
                   Saved ✓
                 </span>
               )}
               {error && (
-                <span
-                  style={{
-                    fontSize: 12,
-                    color: 'var(--color-terracotta)',
-                    fontFamily: 'var(--font-body)',
-                  }}
-                >
+                <span style={{ fontSize: 12, color: 'var(--color-terracotta)', fontFamily: 'var(--font-body)' }}>
                   {error}
                 </span>
               )}
             </div>
-          </>
+          </div>
         )}
       </div>
 
-      {initialUrl && (
+      {/* Preview of what guests actually see */}
+      {!loading && (initial.rsvp_url || initial.invite_url) && (
         <div
           style={{
-            marginTop: 14,
-            padding: '10px 14px',
-            borderRadius: 12,
+            padding: 16,
+            borderRadius: 14,
             background: 'var(--bg-soft-cream)',
             fontSize: 12,
             color: 'var(--text-secondary)',
             fontFamily: 'var(--font-body)',
           }}
         >
-          Currently sending guests to{' '}
-          <a
-            href={initialUrl}
-            target="_blank"
-            rel="noreferrer"
+          <div
             style={{
-              color: 'var(--color-gold-dark)',
-              fontWeight: 500,
-              wordBreak: 'break-all',
+              fontSize: 11,
+              textTransform: 'uppercase',
+              letterSpacing: '0.5px',
+              color: 'var(--text-tertiary)',
+              fontWeight: 600,
+              marginBottom: 8,
             }}
           >
-            {initialUrl}
-          </a>
+            What guests see
+          </div>
+          {initial.rsvp_url && (
+            <div style={{ marginBottom: 6 }}>
+              <strong style={{ color: 'var(--text-primary)' }}>RSVP</strong> →{' '}
+              <a
+                href={initial.rsvp_url}
+                target="_blank"
+                rel="noreferrer"
+                style={{ color: 'var(--color-gold-dark)', wordBreak: 'break-all' }}
+              >
+                {initial.rsvp_url}
+              </a>
+              {initial.rsvp_passcode && (
+                <>
+                  {' '}— passcode{' '}
+                  <code
+                    style={{
+                      background: 'var(--bg-pure-white)',
+                      padding: '1px 6px',
+                      borderRadius: 4,
+                      border: '1px solid var(--border-light)',
+                      fontSize: 11,
+                    }}
+                  >
+                    {initial.rsvp_passcode}
+                  </code>{' '}
+                  copied on tap
+                </>
+              )}
+            </div>
+          )}
+          {initial.invite_url && (
+            <div>
+              <strong style={{ color: 'var(--text-primary)' }}>Invite</strong> →{' '}
+              <a
+                href={initial.invite_url}
+                target="_blank"
+                rel="noreferrer"
+                style={{ color: 'var(--color-gold-dark)', wordBreak: 'break-all' }}
+              >
+                {initial.invite_url}
+              </a>
+            </div>
+          )}
         </div>
       )}
+    </div>
+  );
+}
+
+function Field({
+  label,
+  hint,
+  placeholder,
+  type,
+  value,
+  onChange,
+  disabled,
+  disabledMessage,
+}: {
+  label: string;
+  hint: string;
+  placeholder: string;
+  type: 'url' | 'text';
+  value: string;
+  onChange: (v: string) => void;
+  disabled?: boolean;
+  disabledMessage?: string;
+}) {
+  return (
+    <div>
+      <label
+        style={{
+          display: 'block',
+          fontSize: 11,
+          textTransform: 'uppercase',
+          letterSpacing: '0.5px',
+          color: 'var(--text-tertiary)',
+          marginBottom: 4,
+          fontFamily: 'var(--font-body)',
+          fontWeight: 600,
+        }}
+      >
+        {label}
+      </label>
+      <input
+        type={type}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        disabled={disabled}
+        style={{
+          width: '100%',
+          padding: '10px 12px',
+          borderRadius: 10,
+          border: '1px solid var(--border-light)',
+          background: disabled ? 'var(--bg-soft-cream)' : 'var(--bg-pure-white)',
+          fontSize: 14,
+          fontFamily: 'var(--font-body)',
+          color: 'var(--text-primary)',
+          outline: 'none',
+          boxSizing: 'border-box',
+          opacity: disabled ? 0.7 : 1,
+        }}
+      />
+      <p
+        style={{
+          fontSize: 11,
+          color: 'var(--text-tertiary)',
+          fontFamily: 'var(--font-body)',
+          margin: '4px 0 0',
+          lineHeight: 1.5,
+        }}
+      >
+        {disabled && disabledMessage ? disabledMessage : hint}
+      </p>
     </div>
   );
 }

--- a/app/w/[slug]/home/page.tsx
+++ b/app/w/[slug]/home/page.tsx
@@ -15,6 +15,35 @@ export default function GuestHomePage() {
   const [showPasswordPrompt, setShowPasswordPrompt] = useState(false);
   const [passwordInput, setPasswordInput] = useState('');
   const [passwordError, setPasswordError] = useState(false);
+  const [rsvpToast, setRsvpToast] = useState<string | null>(null);
+
+  // Auto-dismiss the RSVP passcode toast after a few seconds.
+  useEffect(() => {
+    if (!rsvpToast) return;
+    const timeout = window.setTimeout(() => setRsvpToast(null), 3200);
+    return () => window.clearTimeout(timeout);
+  }, [rsvpToast]);
+
+  const handleRsvpClick = async (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (!config?.rsvp_url) return;
+    const passcode = config.rsvp_passcode?.trim();
+    if (!passcode) return; // plain link, let the <a> do its thing
+    // Intercept to copy the passcode before the browser navigates. We still
+    // open in a new tab so the copy action and the navigation both happen
+    // even if writeText fails silently on older mobile browsers.
+    e.preventDefault();
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(passcode);
+        setRsvpToast(`Passcode "${passcode}" copied — paste on the RSVP site.`);
+      } else {
+        setRsvpToast(`Passcode is "${passcode}" — copy it before you continue.`);
+      }
+    } catch {
+      setRsvpToast(`Passcode is "${passcode}" — copy it before you continue.`);
+    }
+    window.open(config.rsvp_url, '_blank', 'noopener,noreferrer');
+  };
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
@@ -166,30 +195,83 @@ export default function GuestHomePage() {
                   </div>
                 ))}
               </div>
-              {config.rsvp_url && (
-                <a
-                  href={config.rsvp_url}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="inline-flex items-center gap-2 rounded-full"
-                  style={{
-                    padding: '10px 18px',
-                    background: 'var(--color-terracotta-gradient)',
-                    color: '#FDFBF7',
-                    fontSize: 13,
-                    fontWeight: 600,
-                    fontFamily: 'var(--font-body)',
-                    textDecoration: 'none',
-                    boxShadow: '0 4px 20px rgba(196, 112, 75, 0.25)',
-                    letterSpacing: '0.02em',
-                  }}
-                >
-                  RSVP details
-                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M7 17L17 7" />
-                    <path d="M8 7h9v9" />
-                  </svg>
-                </a>
+              {(config.rsvp_url || config.invite_url) && (
+                <div className="flex flex-col items-end gap-2">
+                  {config.rsvp_url && (
+                    <a
+                      href={config.rsvp_url}
+                      target="_blank"
+                      rel="noreferrer"
+                      onClick={handleRsvpClick}
+                      className="inline-flex flex-col items-center rounded-full"
+                      style={{
+                        padding: config.rsvp_passcode?.trim() ? '8px 18px' : '10px 18px',
+                        background: 'var(--color-terracotta-gradient)',
+                        color: '#FDFBF7',
+                        fontFamily: 'var(--font-body)',
+                        textDecoration: 'none',
+                        boxShadow: '0 4px 20px rgba(196, 112, 75, 0.25)',
+                        letterSpacing: '0.02em',
+                        lineHeight: 1.15,
+                      }}
+                      title={
+                        config.rsvp_passcode?.trim()
+                          ? 'Copies the passcode to your clipboard and opens the RSVP site.'
+                          : undefined
+                      }
+                    >
+                      <span className="inline-flex items-center gap-2" style={{ fontSize: 13, fontWeight: 600 }}>
+                        RSVP details
+                        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+                          <path d="M7 17L17 7" />
+                          <path d="M8 7h9v9" />
+                        </svg>
+                      </span>
+                      {config.rsvp_passcode?.trim() && (
+                        <span
+                          style={{
+                            fontSize: 10,
+                            opacity: 0.9,
+                            fontWeight: 500,
+                            letterSpacing: '0.04em',
+                            textTransform: 'uppercase',
+                            marginTop: 1,
+                          }}
+                        >
+                          passcode:&nbsp;
+                          <span style={{ fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace', textTransform: 'none', letterSpacing: '0.02em' }}>
+                            {config.rsvp_passcode.trim()}
+                          </span>
+                        </span>
+                      )}
+                    </a>
+                  )}
+                  {config.invite_url && (
+                    <a
+                      href={config.invite_url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="inline-flex items-center gap-2 rounded-full"
+                      style={{
+                        padding: '8px 16px',
+                        background: 'var(--bg-pure-white)',
+                        color: 'var(--color-gold-dark)',
+                        border: '1px solid rgba(198, 163, 85, 0.35)',
+                        fontSize: 12,
+                        fontWeight: 600,
+                        fontFamily: 'var(--font-body)',
+                        textDecoration: 'none',
+                        letterSpacing: '0.02em',
+                      }}
+                    >
+                      View invite
+                      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M7 17L17 7" />
+                        <path d="M8 7h9v9" />
+                      </svg>
+                    </a>
+                  )}
+                </div>
               )}
             </div>
           )}
@@ -655,6 +737,29 @@ export default function GuestHomePage() {
       )}
 
       <BottomNav />
+
+      {/* Passcode copy toast — sits above the BottomNav, auto-dismisses */}
+      {rsvpToast && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="fixed left-1/2 z-[60] rounded-full shadow-lg"
+          style={{
+            bottom: 'calc(env(safe-area-inset-bottom, 0px) + 96px)',
+            transform: 'translateX(-50%)',
+            padding: '10px 16px',
+            background: 'rgba(44, 40, 37, 0.92)',
+            color: '#FDFBF7',
+            fontFamily: 'var(--font-body)',
+            fontSize: 13,
+            maxWidth: 'calc(100vw - 32px)',
+            textAlign: 'center',
+            backdropFilter: 'blur(12px)',
+          }}
+        >
+          {rsvpToast}
+        </div>
+      )}
     </div>
   );
 }

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -84,6 +84,17 @@ export type WeddingConfig = {
    * couple's existing Zola / The Knot / standalone wedding website.
    */
   rsvp_url: string | null;
+  /**
+   * Optional passcode for the external wedding website. When set, clicking
+   * the RSVP button copies this to the clipboard and shows a toast before
+   * opening the link — so guests can just paste on the other side.
+   */
+  rsvp_passcode: string | null;
+  /**
+   * Optional invite link (Canva, Paperless Post, PDF in Drive, etc.).
+   * Surfaces next to the RSVP button on the guest home.
+   */
+  invite_url: string | null;
   events: EventConfig[];
   features: {
     social_feed: boolean;

--- a/tests/unit/components/WeddingProvider.test.tsx
+++ b/tests/unit/components/WeddingProvider.test.tsx
@@ -71,6 +71,8 @@ describe('WeddingProvider', () => {
       enabled_filters: [],
       enabled_ai_styles: [],
       rsvp_url: null,
+      rsvp_passcode: null,
+      invite_url: null,
       events: [],
       venue_city: null,
       venue_country: null,


### PR DESCRIPTION
Two small additions requested together — the RSVP page already existed, so extending it was cheaper than a new page.

Couple side (/dashboard/[id]/rsvp, sidebar now "RSVP & Invite"):
- Three fields instead of one — RSVP URL, RSVP passcode, Invite URL.
- Passcode field is disabled until the RSVP URL is set (doesn't make sense without a destination).
- URL validation happens on the server (zod .url()) and as a client-side check so the obvious "forgot the https" case fails fast.
- "What guests see" preview at the bottom renders the working links plus the passcode in a code-style pill so the couple can sanity-check the guest experience before they ship it.

Guest home (countdown card, right side):
- When rsvp_url is set: the RSVP button now shows the passcode on a second line (monospaced, uppercase label) so guests see the code before they tap. On tap we navigator.clipboard.writeText(passcode), show a toast pinned above the bottom nav with Passcode "love2026" copied — paste on the RSVP site. then window.open the link in a new tab.
- When invite_url is set: a secondary outlined "View invite" button appears below the RSVP button. Opens in a new tab, no clipboard trickery needed.
- Toast auto-dismisses after 3.2s and respects safe-area-inset so it doesn't collide with the notch or the BottomNav.

Scope kept tight: no toast library added, no confirmation dialog, and no per-guest passcode customization. The passcode is the couple's Zola/Joy site passcode — a single string shared across all guests, and surfacing it plainly is the point.