### PR TITLE
Fix setFlag: jsonb_set doesn't create intermediate keys

### DIFF
--- a/lib/feature-flags.ts
+++ b/lib/feature-flags.ts
@@ -64,8 +64,9 @@ export async function setFlag(
     `UPDATE weddings
        SET package_config = jsonb_set(
          COALESCE(package_config, '{}'::jsonb),
-         ARRAY['feature_flags', $2],
-         to_jsonb($3::boolean),
+         ARRAY['feature_flags'],
+         COALESCE(package_config->'feature_flags', '{}'::jsonb)
+           || jsonb_build_object($2::text, $3::boolean),
          true
        )
      WHERE id = $1`,


### PR DESCRIPTION
Real-world bug caught while flipping rich_text_v1 manually in Neon. The previous setFlag() body used jsonb_set with path ARRAY['feature_flags', flag] and create_missing=true — but Postgres's jsonb_set silently no-ops when any path element above the leaf doesn't exist, regardless of create_missing. So the first time we tried to set a flag on a wedding whose package_config had no feature_flags key, the UPDATE reported "UPDATE 1" but wrote the same row back.

Switch to a single-level path (ARRAY['feature_flags']) and build the new value as (existing-or-empty) || {flag: value}. This works whether the parent key exists or not, and preserves any other flags already in the object.

https://claude.ai/code/session_01QVDrfe1YW7KjpLNw6Epr4t