### PR TITLE
QA round-2 follow-up: Findings N + O — FAQ list + Events scope-of-swap

### DIFF
--- a/app/api/v1/dashboard/weddings/[weddingId]/faq/route.ts
+++ b/app/api/v1/dashboard/weddings/[weddingId]/faq/route.ts
@@ -34,7 +34,7 @@ export async function GET(
 
     const pool = getPool();
     const result = await pool.query(
-      `SELECT id, question, answer, source, created_at
+      `SELECT id, question, answer, source, content_format, created_at
        FROM faq_entries WHERE wedding_id = $1
        ORDER BY created_at`,
       [weddingId]
@@ -82,7 +82,7 @@ export async function POST(
       const result = await pool.query(
         `INSERT INTO faq_entries (wedding_id, question, answer, source)
          VALUES ${placeholders.join(', ')}
-         RETURNING id, question, answer, source, created_at`,
+         RETURNING id, question, answer, source, content_format, created_at`,
         values
       );
 

--- a/app/dashboard/[weddingId]/faq/page.tsx
+++ b/app/dashboard/[weddingId]/faq/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, use } from 'react';
 import dynamic from 'next/dynamic';
 import PasswordConfirmDialog from '@/components/ui/PasswordConfirmDialog';
 import { useFeatureFlag } from '@/lib/hooks/useFeatureFlag';
+import { RichText } from '@/lib/rich-text/RichText';
 
 // Lazy-load the Tiptap editor — it's a ~200kb chunk and only needed on
 // Manage pages that author rich content. Keeps the rest of the dashboard
@@ -15,6 +16,7 @@ interface FaqEntry {
   question: string;
   answer: string;
   source: 'manual' | 'zola_import' | 'generated';
+  content_format: 'plain' | 'rich';
   created_at: string;
 }
 
@@ -612,9 +614,9 @@ export default function FaqPage({ params }: { params: Promise<{ weddingId: strin
                           <p style={{ fontSize: 14, fontWeight: 500, color: 'var(--text-primary)', margin: '0 0 6px' }}>
                             {entry.question}
                           </p>
-                          <p style={{ fontSize: 13, color: 'var(--text-secondary)', margin: 0, lineHeight: 1.5, whiteSpace: 'pre-line' }}>
-                            {entry.answer}
-                          </p>
+                          <div style={{ fontSize: 13, color: 'var(--text-secondary)', lineHeight: 1.5 }}>
+                            <RichText value={entry.answer} format={entry.content_format} />
+                          </div>
                           <span
                             style={{
                               fontSize: 10,

--- a/app/dashboard/[weddingId]/settings/page.tsx
+++ b/app/dashboard/[weddingId]/settings/page.tsx
@@ -650,12 +650,22 @@ export default function SettingsPage({ params }: { params: Promise<{ weddingId: 
 
           <div style={{ marginBottom: 16 }}>
             <label style={labelStyle}>Dress Code</label>
-            <textarea
-              style={{ ...inputStyle, minHeight: 60, resize: 'vertical' }}
-              value={dressCode}
-              onChange={(e) => setDressCode(e.target.value)}
-              placeholder="e.g., Black tie, or a longer note about what to wear..."
-            />
+            {richEnabled ? (
+              <RichTextEditor
+                value={dressCode}
+                onChange={setDressCode}
+                weddingId={weddingId}
+                placeholder="e.g., Black tie, or a longer note about what to wear..."
+                minHeight={100}
+              />
+            ) : (
+              <textarea
+                style={{ ...inputStyle, minHeight: 60, resize: 'vertical' }}
+                value={dressCode}
+                onChange={(e) => setDressCode(e.target.value)}
+                placeholder="e.g., Black tie, or a longer note about what to wear..."
+              />
+            )}
           </div>
 
           <div style={{ marginBottom: 16 }}>
@@ -680,12 +690,22 @@ export default function SettingsPage({ params }: { params: Promise<{ weddingId: 
 
           <div style={{ marginBottom: 20 }}>
             <label style={labelStyle}>Logistics / Notes</label>
-            <textarea
-              style={{ ...inputStyle, minHeight: 60, resize: 'vertical' }}
-              value={logistics}
-              onChange={(e) => setLogistics(e.target.value)}
-              placeholder="Parking info, shuttle details, etc."
-            />
+            {richEnabled ? (
+              <RichTextEditor
+                value={logistics}
+                onChange={setLogistics}
+                weddingId={weddingId}
+                placeholder="Parking info, shuttle details, etc."
+                minHeight={100}
+              />
+            ) : (
+              <textarea
+                style={{ ...inputStyle, minHeight: 60, resize: 'vertical' }}
+                value={logistics}
+                onChange={(e) => setLogistics(e.target.value)}
+                placeholder="Parking info, shuttle details, etc."
+              />
+            )}
           </div>
 
           {/* Style Guide Images — only shown when editing an existing event */}

--- a/app/w/[slug]/schedule/page.tsx
+++ b/app/w/[slug]/schedule/page.tsx
@@ -450,9 +450,12 @@ export default async function SchedulePage({
                           {event.style_guide_urls.length > 0 ? 'Style guide' : 'What to wear'}
                         </p>
                         {event.dress_code && (
-                          <p style={{ fontSize: 13, color: 'var(--text-primary)', lineHeight: 1.6, whiteSpace: 'pre-line' }}>
-                            {event.dress_code}
-                          </p>
+                          <div style={{ fontSize: 13, color: 'var(--text-primary)', lineHeight: 1.6 }}>
+                            <RichText
+                              value={event.dress_code}
+                              format={event.content_format ?? 'plain'}
+                            />
+                          </div>
                         )}
 
                         {/* Style guide photos */}


### PR DESCRIPTION
Finding N: GET /dashboard/weddings/{id}/faq was returning rows without content_format, so the dashboard FAQ list view had no way to know which entries to render through the rich renderer. Even with the flag on and the row marked rich, the list still showed raw asterisks. Project content_format on both the listing SELECT and the bulk-INSERT RETURNING, widen the FaqEntry type, and swap the list-view <p whiteSpace:pre-line> for <RichText format={entry.content_format}>.

Finding O: the Events swap shipped in 814f8be only covered description, but across Shriya & Neil's actual rows description is null everywhere — the "Style Guide" block on the guest schedule pulls from dress_code, which still had a plain textarea. Extend the same flag-gated pattern to dress_code and logistics (all three event-narrative fields share the row's content_format since the column is per-row, not per-field). Mirror the swap on the guest schedule page: dress_code now renders through RichText so 'rich' rows get parsed Markdown and 'plain' rows keep their pre-line whitespace behavior.

https://claude.ai/code/session_01QVDrfe1YW7KjpLNw6Epr4t