### PR TITLE
SMS reliability fixes from end-to-end test: US-default phones + crede…

### DIFF
--- a/app/api/v1/dashboard/weddings/[weddingId]/sms/status/route.ts
+++ b/app/api/v1/dashboard/weddings/[weddingId]/sms/status/route.ts
@@ -2,7 +2,7 @@ import { NextRequest } from 'next/server';
 import { handleApiError } from '@/lib/errors';
 import { getPool } from '@/lib/db/client';
 import { getCoupleId, verifyWeddingOwnership } from '@/lib/dashboard-auth';
-import { isTwilioConfigured } from '@/lib/messaging/twilio-client';
+import { isTwilioConfigured, validateTwilioCredentials } from '@/lib/messaging/twilio-client';
 import { normalizePhone } from '@/lib/messaging/normalize-phone';
 import { env } from '@/lib/env';
 
@@ -70,8 +70,17 @@ export async function GET(
       // table missing — ignore
     }
 
+    // Validate the credentials so the banner reflects reality, not just the
+    // presence of env vars. Only worth the round-trip if env vars are set.
+    const configured = isTwilioConfigured();
+    const credCheck = configured
+      ? await validateTwilioCredentials()
+      : { valid: false as boolean | null, error: null };
+
     return Response.json({
-      configured: isTwilioConfigured(),
+      configured,
+      credentials_valid: credCheck.valid,
+      credentials_error: credCheck.error,
       from_number: env.TWILIO_MESSAGING_SERVICE_SID
         ? null // messaging service picks the number per-send
         : env.TWILIO_PHONE_NUMBER || null,

--- a/app/dashboard/[weddingId]/messages/page.tsx
+++ b/app/dashboard/[weddingId]/messages/page.tsx
@@ -17,6 +17,8 @@ interface GuestPickerItem {
 
 interface SmsStatus {
   configured: boolean;
+  credentials_valid: boolean | null;
+  credentials_error: string | null;
   from_number: string | null;
   uses_messaging_service: boolean;
   counts: {
@@ -160,8 +162,14 @@ export default function MessagesPage({ params }: { params: Promise<{ weddingId: 
   const seg = countSegments(body);
   const estCost = audienceCount * seg.segments * EST_COST_PER_SEGMENT;
 
+  const credsRejected = status?.configured === true && status.credentials_valid === false;
+
   const canSend =
-    !!status?.configured && !sending && body.trim().length > 0 && audienceCount > 0;
+    !!status?.configured &&
+    !credsRejected &&
+    !sending &&
+    body.trim().length > 0 &&
+    audienceCount > 0;
 
   const audienceDescription =
     audience === 'custom'
@@ -278,8 +286,36 @@ TWILIO_PHONE_NUMBER=+18445551234`}
         </div>
       )}
 
-      {/* Configured — show from number */}
-      {status?.configured && (
+      {/* Configured but Twilio rejected the credentials */}
+      {credsRejected && (
+        <div
+          style={{
+            padding: 16,
+            borderRadius: 14,
+            background: 'rgba(196,112,75,0.06)',
+            border: '1px solid rgba(196,112,75,0.25)',
+            marginBottom: 24,
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: 12,
+          }}
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--color-terracotta)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0, marginTop: 2 }}>
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="8" x2="12" y2="12" />
+            <line x1="12" y1="16" x2="12.01" y2="16" />
+          </svg>
+          <div style={{ fontSize: 13, color: 'var(--text-secondary)', fontFamily: 'var(--font-body)', lineHeight: 1.5 }}>
+            <strong style={{ color: 'var(--text-primary)' }}>Twilio rejected your credentials.</strong>{' '}
+            {status?.credentials_error || 'Check TWILIO_ACCOUNT_SID and TWILIO_AUTH_TOKEN.'} Sending is
+            disabled until this is fixed in your environment (Vercel → Settings → Environment Variables),
+            then redeploy.
+          </div>
+        </div>
+      )}
+
+      {/* Configured and credentials accepted — show from number */}
+      {status?.configured && !credsRejected && (
         <div
           style={{
             padding: 16,
@@ -441,8 +477,8 @@ TWILIO_PHONE_NUMBER=+18445551234`}
             >
               ⚠ {status.counts.total - status.counts.with_phone} of {status.counts.total} guest
               {status.counts.total - status.counts.with_phone === 1 ? ' has' : 's have'} no usable
-              phone on file (missing number or no country code) and will be skipped. Fix them on
-              the Guests page.
+              phone on file (no number, or one we couldn&apos;t read) and will be skipped. Numbers
+              without a country code are assumed US (+1); fix any others on the Guests page.
             </div>
           )}
         </div>

--- a/lib/messaging/normalize-phone.ts
+++ b/lib/messaging/normalize-phone.ts
@@ -1,25 +1,27 @@
 /**
- * Phone normalization to E.164 for clipboard export into WhatsApp/SMS
- * group-add fields.
+ * Phone normalization to E.164 for SMS sending and clipboard export into
+ * WhatsApp/SMS group-add fields.
  *
- * WhatsApp's Add Participants flow accepts a comma-separated list of E.164
- * numbers (`+34612345678, +1...`). We can't validate against the actual
- * carrier — that requires libphonenumber, which is a 600kb dep we don't
- * need for a copy-button. Instead this is a deliberately permissive
- * heuristic:
+ * We can't validate against the actual carrier — that requires libphonenumber,
+ * a ~600kb dep we don't want for a copy-button and a broadcast field. Instead
+ * this is a deliberately permissive heuristic with a configurable assumption
+ * for numbers that were typed without a country code.
  *
- *   - Strip spaces, dashes, parens, dots.
- *   - If the cleaned string starts with `+`, keep it.
- *   - If it has 11+ digits and no `+`, prepend `+` (international without
- *     the leading `+` — common Spanish/UK pattern).
- *   - If it has 10 digits and no country code, flag ambiguous. We pass it
- *     through *unprefixed* (caller decides whether to include) and surface
- *     a warning the user can act on.
- *   - <7 digits is too short, drop.
+ * `defaultCallingCode` controls how a number with no leading `+` is read:
  *
- * Inline tests at the bottom of the file act as live documentation of
- * intent; they don't run anywhere automated yet, just here for the next
- * person reading.
+ *   '1'  (default) — North American Numbering Plan. A bare 10-digit number
+ *         becomes +1XXXXXXXXXX, and an 11-digit number starting with 1 becomes
+ *         +1XXXXXXXXXX. This is the right assumption for a US/Canada guest
+ *         list, where people habitually store "8122490769" with no +1.
+ *   '44', '34', … — assume that country. A single leading trunk-0 is stripped
+ *         first, so a UK "07700 900123" becomes +447700900123.
+ *   null — strict: never guess. A national-looking number with no country code
+ *         is flagged 'ambiguous_no_country' so the caller can ask the user to
+ *         fix it.
+ *
+ * Non-destructive by design: callers normalize on read/send and never rewrite
+ * the stored value, so a wrong guess is corrected simply by editing the
+ * guest's number (e.g. adding +44) — that explicit country code always wins.
  */
 
 export type NormalizeReason =
@@ -33,41 +35,54 @@ export interface NormalizeResult {
   reason?: NormalizeReason;
 }
 
-export function normalizePhone(raw: string | null | undefined): NormalizeResult {
+export function normalizePhone(
+  raw: string | null | undefined,
+  defaultCallingCode: string | null = '1'
+): NormalizeResult {
   if (!raw) return { ok: false, reason: 'empty' };
 
   const cleaned = raw.replace(/[\s\-().]/g, '');
   if (cleaned.length === 0) return { ok: false, reason: 'empty' };
 
+  // Explicit country code always wins, regardless of the default.
   if (cleaned.startsWith('+')) {
     const digits = cleaned.slice(1);
-    if (digits.length < 7) return { ok: false, reason: 'too_short' };
     if (!/^\d+$/.test(digits)) return { ok: false, reason: 'too_short' };
+    if (digits.length < 7) return { ok: false, reason: 'too_short' };
     return { ok: true, e164: `+${digits}` };
   }
 
   if (!/^\d+$/.test(cleaned)) return { ok: false, reason: 'too_short' };
 
-  if (cleaned.length >= 11) {
-    return { ok: true, e164: `+${cleaned}` };
+  // No '+'. Interpret based on the configured default country.
+  if (defaultCallingCode === '1') {
+    // NANP: a complete national number is exactly 10 digits.
+    if (cleaned.length === 10) return { ok: true, e164: `+1${cleaned}` };
+    if (cleaned.length === 11 && cleaned.startsWith('1')) {
+      return { ok: true, e164: `+${cleaned}` };
+    }
+    // 12+ digits (or 11 not starting with 1) is already an international
+    // number typed without its '+' — keep it rather than forcing +1.
+    if (cleaned.length >= 11) return { ok: true, e164: `+${cleaned}` };
+    // 7-9 digits can't be a complete NANP number.
+    return { ok: false, reason: 'too_short' };
   }
 
-  if (cleaned.length >= 7) {
-    // Likely US 10-digit or similar — couple paste-edited the country code
-    // off. Surface this so they can fix the row, but don't drop the number.
-    return { ok: false, reason: 'ambiguous_no_country' };
+  if (defaultCallingCode) {
+    // Already leads with this country's code and is long enough → full
+    // international number typed without '+'.
+    if (cleaned.length >= 11 && cleaned.startsWith(defaultCallingCode)) {
+      return { ok: true, e164: `+${cleaned}` };
+    }
+    // Otherwise treat as a national number: drop a single trunk-0 prefix and
+    // prepend the calling code.
+    const national = cleaned.replace(/^0+/, '');
+    if (national.length < 6) return { ok: false, reason: 'too_short' };
+    return { ok: true, e164: `+${defaultCallingCode}${national}` };
   }
 
+  // Strict mode: never guess a country.
+  if (cleaned.length >= 11) return { ok: true, e164: `+${cleaned}` };
+  if (cleaned.length >= 7) return { ok: false, reason: 'ambiguous_no_country' };
   return { ok: false, reason: 'too_short' };
 }
-
-// Inline test cases — documentation of intent:
-//
-//   normalizePhone(null)              → { ok: false, reason: 'empty' }
-//   normalizePhone('')                → { ok: false, reason: 'empty' }
-//   normalizePhone('+34 612 34 56 78')→ { ok: true,  e164: '+34612345678' }
-//   normalizePhone('+1-555-867-5309') → { ok: true,  e164: '+15558675309' }
-//   normalizePhone('34612345678')     → { ok: true,  e164: '+34612345678' }
-//   normalizePhone('5558675309')      → { ok: false, reason: 'ambiguous_no_country' }
-//   normalizePhone('1234')            → { ok: false, reason: 'too_short' }
-//   normalizePhone('+34abc')          → { ok: false, reason: 'too_short' }

--- a/lib/messaging/twilio-client.ts
+++ b/lib/messaging/twilio-client.ts
@@ -35,12 +35,60 @@ export interface SendSmsResult {
 // Friendlier text for the Twilio error codes a wedding couple is most
 // likely to hit, keyed by https://www.twilio.com/docs/api/errors
 const ERROR_HINTS: Record<number, string> = {
+  20003: 'Twilio rejected the account credentials — check TWILIO_ACCOUNT_SID and TWILIO_AUTH_TOKEN in your environment',
   21211: 'Invalid phone number',
   21408: 'SMS not enabled for this region on your Twilio account',
   21610: 'This guest replied STOP and carriers block further texts to them',
   21614: 'Not a mobile number (landline?)',
   30032: 'Toll-free number not yet verified — finish verification in the Twilio console',
 };
+
+/**
+ * Cheaply check whether the configured credentials actually work, by fetching
+ * the Account resource. Returns:
+ *   valid: true  — Twilio accepted the SID + token
+ *   valid: false — Twilio rejected them (error explains why)
+ *   valid: null  — couldn't reach Twilio (network/timeout) — unknown, don't
+ *                  cry wolf in the UI on a transient blip
+ *
+ * This backs the "configured" banner so it reflects reality, not just the
+ * presence of env vars.
+ */
+export async function validateTwilioCredentials(): Promise<{
+  valid: boolean | null;
+  error: string | null;
+}> {
+  if (!isTwilioConfigured()) return { valid: false, error: 'Twilio is not configured' };
+
+  const accountSid = env.TWILIO_ACCOUNT_SID!;
+  try {
+    const res = await fetch(
+      `https://api.twilio.com/2010-04-01/Accounts/${accountSid}.json`,
+      {
+        headers: {
+          Authorization:
+            'Basic ' +
+            Buffer.from(`${accountSid}:${env.TWILIO_AUTH_TOKEN}`).toString('base64'),
+        },
+        signal: AbortSignal.timeout(5000),
+      }
+    );
+    if (res.ok) return { valid: true, error: null };
+
+    const data = await res.json().catch(() => null);
+    const code: number | undefined = data?.code;
+    const hint = code !== undefined ? ERROR_HINTS[code] : undefined;
+    return {
+      valid: false,
+      error: hint || data?.message || `Twilio returned HTTP ${res.status}`,
+    };
+  } catch (err) {
+    return {
+      valid: null,
+      error: err instanceof Error ? err.message : 'Could not reach Twilio',
+    };
+  }
+}
 
 /**
  * Send a single SMS. Returns { sid, error } — never throws so batch

--- a/tests/unit/messaging/normalize-phone.test.ts
+++ b/tests/unit/messaging/normalize-phone.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { normalizePhone } from '@/lib/messaging/normalize-phone';
+
+describe('normalizePhone', () => {
+  it('returns empty for null/blank', () => {
+    expect(normalizePhone(null).reason).toBe('empty');
+    expect(normalizePhone('').reason).toBe('empty');
+    expect(normalizePhone('   ').reason).toBe('empty');
+  });
+
+  it('keeps an explicit + country code, stripping formatting', () => {
+    expect(normalizePhone('+1-555-867-5309').e164).toBe('+15558675309');
+    expect(normalizePhone('+34 612 34 56 78').e164).toBe('+34612345678');
+  });
+
+  describe('US default (+1)', () => {
+    it('assumes +1 for a bare 10-digit number', () => {
+      expect(normalizePhone('8122490769')).toEqual({ ok: true, e164: '+18122490769' });
+      expect(normalizePhone('(812) 249-0769').e164).toBe('+18122490769');
+    });
+
+    it('treats 11 digits starting with 1 as +1', () => {
+      expect(normalizePhone('18122490769').e164).toBe('+18122490769');
+    });
+
+    it('keeps a longer international number typed without +', () => {
+      // 91 + 10-digit India number, no leading + — do not force +1
+      expect(normalizePhone('919876543210').e164).toBe('+919876543210');
+    });
+
+    it('rejects too-short numbers (not a complete US number)', () => {
+      expect(normalizePhone('8675309').ok).toBe(false);
+      expect(normalizePhone('1234').reason).toBe('too_short');
+    });
+
+    it('rejects numbers with letters', () => {
+      expect(normalizePhone('+34abc').ok).toBe(false);
+      expect(normalizePhone('call-me').ok).toBe(false);
+    });
+  });
+
+  describe('configured non-US default', () => {
+    it('prepends the calling code and strips a trunk-0 (UK)', () => {
+      expect(normalizePhone('07700 900123', '44').e164).toBe('+447700900123');
+      expect(normalizePhone('612345678', '34').e164).toBe('+34612345678');
+    });
+
+    it('keeps a full international number that already leads with the code', () => {
+      expect(normalizePhone('447700900123', '44').e164).toBe('+447700900123');
+    });
+
+    it('still honors an explicit + code over the default', () => {
+      expect(normalizePhone('+15558675309', '44').e164).toBe('+15558675309');
+    });
+  });
+
+  describe('strict mode (null)', () => {
+    it('flags a bare 10-digit number as ambiguous rather than guessing', () => {
+      expect(normalizePhone('5558675309', null).reason).toBe('ambiguous_no_country');
+    });
+
+    it('keeps an 11+ digit number as international', () => {
+      expect(normalizePhone('34612345678', null).e164).toBe('+34612345678');
+    });
+  });
+});


### PR DESCRIPTION
…ntial validation

Two issues surfaced testing the Texts feature against a real Zola-imported guest list and a live (misconfigured) Twilio account:

1. Bare US numbers were unsendable. Imported lists store 10-digit numbers with no country code (e.g. 8122490769); the normalizer flagged them 'ambiguous' and skipped them, so an all-US list showed '0 with phone'. normalizePhone now takes a defaultCallingCode (default '1'): 10 digits → +1XXXXXXXXXX, 11 starting with 1 → +1..., longer-without-+ kept as international. Pass '44' etc. (strips a trunk-0) for a non-US list, or null for strict. Non-destructive: stored values are never rewritten, so an explicit +44 on a guest always wins. All five call sites (both dashboard pages, both SMS routes, WhatsApp export) benefit automatically. 12 new unit tests.

2. The 'configured' banner lied. It only checked that env vars were present, not that Twilio accepted them — so a wrong Account SID still showed the green 'Texting from...' banner and every send failed with an auth error. Added validateTwilioCredentials() (cheap GET on the Account resource); status now returns credentials_valid (true/false/null-if-unreachable). The page shows a red 'Twilio rejected your credentials' banner and disables sending when creds are bad, with the specific Twilio message.

Texts-page skip warning updated to explain the US assumption.

https://claude.ai/code/session_01QVDrfe1YW7KjpLNw6Epr4t